### PR TITLE
Remove organization and region from aws module variables

### DIFF
--- a/aws/_modules/eks/variables.tf
+++ b/aws/_modules/eks/variables.tf
@@ -1,8 +1,3 @@
-variable "organization" {
-  type        = "string"
-  description = "Organization the cluster belongs to."
-}
-
 variable "metadata_name" {
   type        = "string"
   description = "Metadata name to use."
@@ -16,11 +11,6 @@ variable "metadata_fqdn" {
 variable "metadata_labels" {
   type        = "map"
   description = "Metadata labels to use."
-}
-
-variable "region" {
-  type        = "string"
-  description = "AWS region to start the cluster in."
 }
 
 variable "availability_zones" {

--- a/aws/cluster/configuration.tf
+++ b/aws/cluster/configuration.tf
@@ -12,10 +12,6 @@ locals {
 
   base_domain = "${lookup(local.cfg, "base_domain")}"
 
-  organization = "${lookup(local.cfg, "organization")}"
-
-  region = "${lookup(local.cfg, "region")}"
-
   cluster_availability_zones_lookup = "${lookup(local.cfg, "cluster_availability_zones", "")}"
   cluster_availability_zones        = "${split(",", local.cluster_availability_zones_lookup)}"
 

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -1,3 +1,5 @@
+data "aws_region" "current" {}
+
 module "cluster_metadata" {
   source = "../../common/metadata"
 
@@ -5,14 +7,11 @@ module "cluster_metadata" {
   base_domain = "${local.base_domain}"
 
   provider_name   = "aws"
-  provider_region = "${local.region}"
+  provider_region = "${data.aws_region.current.name}"
 }
 
 module "cluster" {
   source = "../_modules/eks"
-
-  organization = "${local.organization}"
-  region       = "${local.region}"
 
   metadata_name   = "${module.cluster_metadata.name}"
   metadata_fqdn   = "${module.cluster_metadata.fqdn}"


### PR DESCRIPTION
The AWS provider requires a region and multiple providers are
required to handle multiple regions. Hence, we do not try to outsmart
ourselves here but instead use provider injection into the module
to handle regions as well as organizations (let provider assume a role).

As such, there is no need to pass region or organization into the
cluster and eks modules.