### PR TITLE
enabling macos to exec kubectl_apply

### DIFF
--- a/common/cluster_services/kubectl_apply.sh
+++ b/common/cluster_services/kubectl_apply.sh
@@ -2,7 +2,11 @@
 
 set -e
 
-echo "${KUBECONFIG_DATA}" | base64 -d > $KUBECONFIG
+if [ "$(uname -s)" == "Darwin" ]; then
+    echo "${KUBECONFIG_DATA}" | base64 -D > $KUBECONFIG
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    echo "${KUBECONFIG_DATA}" | base64 -d > $KUBECONFIG
+fi
 
 if [ -s $1 ]
 then


### PR DESCRIPTION
with macOS I got this error in the moment I try to run
```
terraform workspace new ops
terraform apply
```

```
module.kind_zero.module.cluster.module.cluster_services.null_resource.cluster_services: Provisioning with 'local-exec'...
module.kind_zero.module.cluster.module.cluster_services.null_resource.cluster_services (local-exec): Executing: ["/bin/sh" "-c" "/Users/nullck/Documents/YARA/kubestack_local/infra-quickstart-kind/.terraform/modules/d00e427fa228231462c4208b4986c053/kubectl_apply.sh /Users/nullck/Documents/YARA/kubestack_local/infra-quickstart-kind/clusters/testing-ops-localhost.kind.infra.local/cluster_services.yaml"]
module.kind_zero.module.cluster.module.cluster_services.null_resource.cluster_services (local-exec): base64: invalid option -- d
module.kind_zero.module.cluster.module.cluster_services.null_resource.cluster_services (local-exec): Usage:	base64 [-hvD] [-b num] [-i in_file] [-o out_file]
module.kind_zero.module.cluster.module.cluster_services.null_resource.cluster_services (local-exec):   -h, --help     display this message
module.kind_zero.module.cluster.module.cluster_services.null_resource.cluster_services (local-exec):   -D, --decode   decodes input
module.kind_zero.module.cluster.module.cluster_services.null_resource.cluster_services (local-exec):   -b, --break    break encoded string into num character lines
module.kind_zero.module.cluster.module.cluster_services.null_resource.cluster_services (local-exec):   -i, --input    input file (default: "-" for stdin)
module.kind_zero.module.cluster.module.cluster_services.null_resource.cluster_services (local-exec):   -o, --output   output file (default: "-" for stdout)
```

To fix I did this change to check the OS first and use the parameter *-d* or *-D* in the base64 command.
since in the macos base64 binary we have *-D*  for decode and in Linux we have  *-d*  