### PR TITLE
EKS: Allow configuring mapRoles, mapUsers and mapAccounts fix #68

### DIFF
--- a/aws/_modules/eks/aws_iam_authenticator.tf
+++ b/aws/_modules/eks/aws_iam_authenticator.tf
@@ -13,10 +13,13 @@ resource "kubernetes_config_map" "current" {
   groups:
     - system:bootstrappers
     - system:nodes
+${var.aws_auth_map_roles}
 MAPROLES
 
+    mapUsers = var.aws_auth_map_users
+
+    mapAccounts = var.aws_auth_map_accounts
   }
 
   depends_on = [aws_eks_cluster.current]
 }
-

--- a/aws/_modules/eks/variables.tf
+++ b/aws/_modules/eks/variables.tf
@@ -38,3 +38,17 @@ variable "min_size" {
   type        = string
 }
 
+variable "aws_auth_map_roles" {
+  description = "mapRoles entries added to aws-auth configmap"
+  type        = string
+}
+
+variable "aws_auth_map_users" {
+  description = "mapUsers entries added to aws-auth configmap"
+  type        = string
+}
+
+variable "aws_auth_map_accounts" {
+  description = "mapAccounts entries added to aws-auth configmap"
+  type        = string
+}

--- a/aws/cluster/configuration.tf
+++ b/aws/cluster/configuration.tf
@@ -22,5 +22,8 @@ locals {
   cluster_max_size = local.cfg["cluster_max_size"]
 
   cluster_min_size = local.cfg["cluster_min_size"]
-}
 
+  cluster_aws_auth_map_roles    = lookup(local.cfg, "cluster_aws_auth_map_roles", "")
+  cluster_aws_auth_map_users    = lookup(local.cfg, "cluster_aws_auth_map_users", "")
+  cluster_aws_auth_map_accounts = lookup(local.cfg, "cluster_aws_auth_map_accounts", "")
+}

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -23,5 +23,8 @@ module "cluster" {
   desired_capacity   = local.cluster_desired_capacity
   max_size           = local.cluster_max_size
   min_size           = local.cluster_min_size
-}
 
+  aws_auth_map_roles    = local.cluster_aws_auth_map_roles
+  aws_auth_map_users    = local.cluster_aws_auth_map_users
+  aws_auth_map_accounts = local.cluster_aws_auth_map_accounts
+}


### PR DESCRIPTION
Allow users to configure aws-iam-authenticator by adding
variables to allow adding entries to mapRols, mapUsers and
mapAccounts.

Here's an example of how to use this in the config.auto.tfvars:

```
cluster_aws_auth_map_roles = <<MAPROLES
- roleARN: arn:aws:iam::000000000000:role/KubernetesAdmin
  username: kubernetes-admin
  groups:
  - system:masters
MAPROLES
```

```
cluster_aws_auth_map_users = <<MAPUSERS
- userARN: arn:aws:iam::000000000000:user/Alice
  username: alice
  groups:
  - system:masters
MAPUSERS
```

```
cluster_aws_auth_map_accounts = <<MAPACCOUNTS
- "012345678901"
- "456789012345"
MAPACCOUNTS
```