### PR TITLE
Add libffi to fix azure cli build

### DIFF
--- a/quickstart/src/ci-cd/Dockerfile
+++ b/quickstart/src/ci-cd/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     gcc \
     unzip \
-    python-virtualenv
+    python-virtualenv \
+    libffi-dev 
 
 RUN mkdir -p /opt/bin
 


### PR DESCRIPTION
The quickstart docker image build fails when compiling azure cli due to missing libffi. This PR adds missing library to Dockefile.