### PR TITLE
EKS: Force node_pool to depend on aws-auth configmap

### DIFF
--- a/aws/_modules/eks/node_pool.tf
+++ b/aws/_modules/eks/node_pool.tf
@@ -1,4 +1,8 @@
 module "node_pool" {
+  providers = {
+    kubernetes = kubernetes.eks
+  }
+
   source = "./node_pool"
 
   metadata_labels   = var.metadata_labels
@@ -17,4 +21,10 @@ module "node_pool" {
   min_size      = var.min_size
 
   disk_size = var.root_device_volume_size
+
+  # force node_pool to depend on aws-auth configmap
+  depends-on-aws-auth = {
+    name      = kubernetes_config_map.current.metadata[0].name
+    namespace = kubernetes_config_map.current.metadata[0].namespace
+  }
 }

--- a/aws/_modules/eks/node_pool/main.tf
+++ b/aws/_modules/eks/node_pool/main.tf
@@ -1,3 +1,17 @@
+data "kubernetes_config_map" "aws_auth" {
+  # Force an explicit depends_on, on the configmap
+  # before creating the node pool
+  # Otherwise the aws_eks_node_group resource
+  # creates the configmap leaving TF to error
+  # out because it already exists
+
+  metadata {
+    name      = var.depends-on-aws-auth.name
+    namespace = var.depends-on-aws-auth.namespace
+  }
+}
+
+
 resource "aws_eks_node_group" "nodes" {
   cluster_name    = var.cluster_name
   node_group_name = var.node_group_name
@@ -15,4 +29,6 @@ resource "aws_eks_node_group" "nodes" {
 
   tags   = var.eks_metadata_tags
   labels = var.metadata_labels
+
+  depends_on = [data.kubernetes_config_map.aws_auth]
 }

--- a/aws/_modules/eks/node_pool/variables.tf
+++ b/aws/_modules/eks/node_pool/variables.tf
@@ -53,3 +53,8 @@ variable "subnet_ids" {
   type        = list(string)
   description = "List of VPC subnet IDs to use for nodes."
 }
+
+variable "depends-on-aws-auth" {
+  type        = map(string)
+  description = "Used as a depends_on shim to first create the aws-auth configmap before creating the node_pool."
+}


### PR DESCRIPTION
Using the `eks_node_group` resource the configmap is created by AWS.
This causes an error because it already exists, when the kubernetes
provider tries to create it.

To allow framework users to modify the configmap to control `mapRoles`,
`mapAccounts` and `mapUsers` this commit makes the node_pool module
depend on the configmap.