### PR TITLE
Update azurerm provider and fix breaking changes

### DIFF
--- a/azurerm/_modules/aks/ingress.tf
+++ b/azurerm/_modules/aks/ingress.tf
@@ -5,6 +5,7 @@ resource "azurerm_public_ip" "current" {
   location            = azurerm_kubernetes_cluster.current.location
   resource_group_name = azurerm_kubernetes_cluster.current.node_resource_group
   allocation_method   = "Static"
+  sku                 = "Standard"
 
   tags = var.metadata_labels
 

--- a/azurerm/_modules/aks/service_principal.tf
+++ b/azurerm/_modules/aks/service_principal.tf
@@ -14,6 +14,5 @@ resource "random_string" "password" {
 resource "azuread_service_principal_password" "current" {
   service_principal_id = azuread_service_principal.current.id
   value                = random_string.password.result
-  end_date_relative    = "2160h" # valid for 90 days
+  end_date_relative    = var.service_principal_end_date_relative
 }
-

--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -86,3 +86,8 @@ variable "disable_default_ingress" {
   type        = bool
   description = "Whether to disable the default ingress."
 }
+
+variable "service_principal_end_date_relative" {
+  type        = string
+  description = "Relative time in hours for which the service principal password is valid. Defaults to 1 year."
+}

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -33,4 +33,6 @@ locals {
   manifest_path         = var.manifest_path != null ? var.manifest_path : local.manifest_path_default
 
   disable_default_ingress = lookup(local.cfg, "disable_default_ingress", false)
+
+  service_principal_end_date_relative = lookup(local.cfg, "service_principal_end_date_relative", "8766h")
 }

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -25,7 +25,7 @@ locals {
   default_node_pool_max_count           = lookup(local.cfg, "default_node_pool_max_count", "1")
   default_node_pool_node_count          = lookup(local.cfg, "default_node_pool_node_count", "1")
 
-  default_node_pool_vm_size = lookup(local.cfg, "default_node_pool_vm_size", "Standard_D1_v2")
+  default_node_pool_vm_size = lookup(local.cfg, "default_node_pool_vm_size", "Standard_B2s")
 
   default_node_pool_os_disk_size_gb = lookup(local.cfg, "default_node_pool_os_disk_size_gb", "30")
 

--- a/azurerm/cluster/main.tf
+++ b/azurerm/cluster/main.tf
@@ -41,4 +41,6 @@ module "cluster" {
   manifest_path = local.manifest_path
 
   disable_default_ingress = local.disable_default_ingress
+
+  service_principal_end_date_relative = local.service_principal_end_date_relative
 }

--- a/azurerm/cluster/providers.tf
+++ b/azurerm/cluster/providers.tf
@@ -5,7 +5,7 @@ provider "external" {
 
 # https://github.com/terraform-providers/terraform-provider-azurerm/releases
 provider "azurerm" {
-  version = "~> 2.13.0"
+  version = "~> 2.23.0"
 
   features {}
 }


### PR DESCRIPTION
 * Starting with `v2.14.0` the provider talks to a new AKS API
   which enforces a min. of 2 cpu cores and 4GB memory for nodes.

   This commit updates the default vm_size. Configurations that
   relied on this default, will see a destroy and recreate TF plan.

   To avoid this, explicitly set the previous default for existing
   clusters.

 * Azure introduced Standard and Basic SKUs for loadbalancers
   and public IPs. The SKUs of loadbalancers and IPs have to
   match. By default public IPs are Basic and loadbalancers
   created by Kubernetes are Standard. This commit changes
   the IPs created by Terraform to use the Standard SKU.

   Changing the SKU forces a new IP.