### PR TITLE
Update kindest/node docker image to v1.16.9

### DIFF
--- a/kind/cluster/configuration.tf
+++ b/kind/cluster/configuration.tf
@@ -12,7 +12,7 @@ locals {
 
   base_domain = local.cfg["base_domain"]
 
-  node_image  = lookup(local.cfg, "node_image", "kindest/node:v1.16.1")
+  node_image  = lookup(local.cfg, "node_image", "kindest/node:v1.16.9")
   extra_nodes = lookup(local.cfg, "extra_nodes", "")
 
   http_port_default = terraform.workspace == "apps" ? 80 : 8080


### PR DESCRIPTION
I had some problems with installing prometheus-operator with Kubernetes in Docker in version 1.16.1. A similar issue was reported here https://github.com/helm/charts/issues/17511. 

This could be fixed with upgrading the docker kind image to version v1.16.9.