### PR TITLE
Extend configuration inheritance implementation

### DIFF
--- a/aws/cluster/configuration.tf
+++ b/aws/cluster/configuration.tf
@@ -1,12 +1,13 @@
-locals {
-  # apps config and merged ops config
-  workspaces = {
-    apps = var.configuration["apps"]
-    ops  = merge(var.configuration["apps"], var.configuration["ops"])
-  }
+module "configuration" {
+  source = "../../common/configuration"
 
+  configuration = var.configuration
+  base_key      = var.base_key
+}
+
+locals {
   # current workspace config
-  cfg = local.workspaces[terraform.workspace]
+  cfg = module.configuration.merged[terraform.workspace]
 
   name_prefix = local.cfg["name_prefix"]
 

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -1,12 +1,13 @@
-locals {
-  # apps config and merged ops config
-  workspaces = {
-    apps = var.configuration["apps"]
-    ops  = merge(var.configuration["apps"], var.configuration["ops"])
-  }
+module "configuration" {
+  source = "../../common/configuration"
 
+  configuration = var.configuration
+  base_key      = var.base_key
+}
+
+locals {
   # current workspace config
-  cfg = local.workspaces[terraform.workspace]
+  cfg = module.configuration.merged[terraform.workspace]
 
   name_prefix = local.cfg["name_prefix"]
 

--- a/azurerm/cluster/variables.tf
+++ b/azurerm/cluster/variables.tf
@@ -8,3 +8,9 @@ variable "manifest_path" {
   description = "Path to Kustomize overlay to build."
   default     = null
 }
+
+variable "base_key" {
+  type        = string
+  description = "The key in the configuration map all other keys inherit from."
+  default     = "apps"
+}

--- a/common/configuration/outputs.tf
+++ b/common/configuration/outputs.tf
@@ -1,0 +1,15 @@
+locals {
+  base = {
+    (var.base_key) = var.configuration[var.base_key]
+  }
+
+  overlays = {
+    for name, _ in var.configuration :
+    name => merge(var.configuration[var.base_key], var.configuration[name])
+    if name != var.base_key
+  }
+}
+
+output "merged" {
+  value = merge(local.base, local.overlays)
+}

--- a/common/configuration/variables.tf
+++ b/common/configuration/variables.tf
@@ -3,14 +3,7 @@ variable "configuration" {
   description = "Map with per workspace cluster configuration."
 }
 
-variable "manifest_path" {
-  type        = string
-  description = "Path to Kustomize overlay to build."
-  default     = null
-}
-
 variable "base_key" {
   type        = string
   description = "The key in the configuration map all other keys inherit from."
-  default     = "apps"
 }

--- a/common/configuration/versions.tf
+++ b/common/configuration/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -1,12 +1,13 @@
-locals {
-  # apps config and merged ops config
-  workspaces = {
-    apps = var.configuration["apps"]
-    ops  = merge(var.configuration["apps"], var.configuration["ops"])
-  }
+module "configuration" {
+  source = "../../common/configuration"
 
+  configuration = var.configuration
+  base_key      = var.base_key
+}
+
+locals {
   # current workspace config
-  cfg = local.workspaces[terraform.workspace]
+  cfg = module.configuration.merged[terraform.workspace]
 
   name_prefix = local.cfg["name_prefix"]
 

--- a/google/cluster/variables.tf
+++ b/google/cluster/variables.tf
@@ -8,3 +8,9 @@ variable "manifest_path" {
   description = "Path to Kustomize overlay to build."
   default     = null
 }
+
+variable "base_key" {
+  type        = string
+  description = "The key in the configuration map all other keys inherit from."
+  default     = "apps"
+}

--- a/kind/cluster/configuration.tf
+++ b/kind/cluster/configuration.tf
@@ -1,12 +1,13 @@
-locals {
-  # apps config and merged ops config
-  workspaces = {
-    apps = var.configuration["apps"]
-    ops  = merge(var.configuration["apps"], var.configuration["ops"])
-  }
+module "configuration" {
+  source = "../../common/configuration"
 
+  configuration = var.configuration
+  base_key      = var.base_key
+}
+
+locals {
   # current workspace config
-  cfg = local.workspaces[terraform.workspace]
+  cfg = module.configuration.merged[terraform.workspace]
 
   name_prefix = local.cfg["name_prefix"]
 

--- a/kind/cluster/variables.tf
+++ b/kind/cluster/variables.tf
@@ -8,3 +8,9 @@ variable "manifest_path" {
   description = "Path to Kustomize overlay to build."
   default     = null
 }
+
+variable "base_key" {
+  type        = string
+  description = "The key in the configuration map all other keys inherit from."
+  default     = "apps"
+}


### PR DESCRIPTION
This commit moves the implementation of the configuration
inheritance into a shared module and extends it to support
two commonly requested use-cases.

 1. Support for custom names instead of apps and ops, fix #126
 2. Support for more than two infrastructure environments

The module expects two input variables, `configuration` and
`base_key`.

`configuration` is a map of maps, and `base_key` sets the key
in the configuration map that all other keys will inherit from.

So, with the frameworks default apps and ops inheritance and
configuration, it has the exact same behavior as before. Ops
inherits from apps and overwrites values.

But given a Terraform configuration with different and more keys:

```
locals {
  cfg = {
    "a" = {
      "a" = "a"
      "b" = null
    }
    "b" = {
      "b" = "b"
    }
    "c" = {
      "c" = "c"
    }
  }
}

module "configuration" {
  source = "../common/configuration"

  configuration = local.cfg
  base_key      = "a"
}

output "merged_cfg" {
  value = module.configuration.merged
}
```

The merged_cfg output will be:

```
merged_cfg = {
  "a" = {
    "a" = "a"
  }
  "b" = {
    "a" = "a"
    "b" = "b"
  }
  "c" = {
    "a" = "a"
    "c" = "c"
  }
}
```

Until futher notice the framework documents and tests
only the apps and ops case. So, here be dragons, you've been warned.

But users can now adjust environment names and number to their liking.
Provided they also align the the tagging strategy and triggers
in the pipeline accordingly.