### PR TITLE
Added private endpoint option to GKE setup

### DIFF
--- a/google/_modules/gke/cluster.tf
+++ b/google/_modules/gke/cluster.tf
@@ -49,4 +49,17 @@ resource "google_container_cluster" "current" {
       start_time = var.daily_maintenance_window_start_time
     }
   }
+
+  private_cluster_config {
+    enable_private_nodes    = var.enable_private_nodes
+    enable_private_endpoint = false
+    master_ipv4_cidr_block  = var.master_cidr_block
+  }
+
+  dynamic "ip_allocation_policy" {
+    for_each = var.enable_private_nodes ? toset([1]) : []
+
+    content {}
+  }
 }
+

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -113,3 +113,13 @@ variable "disable_default_ingress" {
   type        = bool
   description = "Whether to disable the default ingress."
 }
+
+variable "enable_private_nodes" {
+  type        = bool
+  description = "Whether to enable private nodes"
+}
+
+variable "master_cidr_block" {
+  type        = string
+  description = "The IP range for the master network"
+}

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -56,4 +56,8 @@ locals {
   manifest_path         = var.manifest_path != null ? var.manifest_path : local.manifest_path_default
 
   disable_default_ingress = lookup(local.cfg, "disable_default_ingress", false)
+
+  enable_private_nodes    = lookup(local.cfg, "enable_private_nodes", true)
+  master_cidr_block       = lookup(local.cfg, "master_cidr_block", "172.16.0.32/28")
 }
+

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -47,4 +47,7 @@ module "cluster" {
   manifest_path = local.manifest_path
 
   disable_default_ingress = local.disable_default_ingress
+
+  enable_private_nodes    = local.enable_private_nodes
+  master_cidr_block       = local.master_cidr_block
 }


### PR DESCRIPTION
## Problem
By default GKE assigns an IP address to every node that it spins up, this in itself is not a problem however unless requested a Google Cloud Project has Quotas on the amount of Public IP's a project can have (I believe the default is 8). Therefore if you are not careful your cluster can not scale or do rolling updates do to insufficient IP's 

## Changelog

- Adds the ability to have private endpoints in the Google Kubernetes Cluster

