### PR TITLE
Expose cluster name_servers as module output

### DIFF
--- a/aws/_modules/eks/outputs.tf
+++ b/aws/_modules/eks/outputs.tf
@@ -1,3 +1,3 @@
-output "cluster_ns" {
+output "default_ingress_nameservers" {
   value = var.disable_default_ingress ? null : aws_route53_zone.current[0].name_servers
 }

--- a/aws/_modules/eks/outputs.tf
+++ b/aws/_modules/eks/outputs.tf
@@ -1,0 +1,3 @@
+output "name_servers" {
+  value = ingress.aws_route53.zone.current.name_servers
+}

--- a/aws/_modules/eks/outputs.tf
+++ b/aws/_modules/eks/outputs.tf
@@ -1,3 +1,3 @@
-output "name_servers" {
-  value = ingress.aws_route53.zone.current.name_servers
+output "cluster_ns" {
+  value = var.disable_default_ingress ? null : aws_route53_zone.current[0].name_servers
 }

--- a/aws/cluster/outputs.tf
+++ b/aws/cluster/outputs.tf
@@ -1,0 +1,3 @@
+output "name_servers" {
+  value = module.cluster.name_servers
+}

--- a/aws/cluster/outputs.tf
+++ b/aws/cluster/outputs.tf
@@ -1,3 +1,3 @@
-output "cluster_ns" {
-  value = module.cluster.cluster_ns
+output "default_ingress_nameservers" {
+  value = module.cluster.default_ingress_nameservers
 }

--- a/aws/cluster/outputs.tf
+++ b/aws/cluster/outputs.tf
@@ -1,3 +1,3 @@
 output "name_servers" {
-  value = module.cluster.name_servers
+  value = module.cluster.cluster_ns
 }

--- a/aws/cluster/outputs.tf
+++ b/aws/cluster/outputs.tf
@@ -1,3 +1,3 @@
-output "name_servers" {
+output "cluster_ns" {
   value = module.cluster.cluster_ns
 }


### PR DESCRIPTION
It would be useful to be able to retrieve cluster ingress nameservers programmatically, i.e. in cases where one wants to control the top-level zone while delegating authority to the cluster nameservers managing the `base_domain` defined in `config.auto.tfvars`.

### Current behavior

Currently, to see the cluster ingress nameservers, one must do something like:
```
terraform state show module.eks_zero.module.cluster.aws_route53_zone.current[0]
```

### Proposed behavior

The proposed change expresses the nameservers as outputs, allowing one to retrieve them programmatically, e.g. `module.eks_zero.default_ingress_nameservers`, in order to do things like:

```
resource "aws_route53_record" "cluster-ns" {
  zone_id         = aws_route53_zone.root.zone_id
  allow_overwrite = true
  name            = var.clusters.eks_zero.apps.base_domain
  type            = "NS"
  ttl             = "60"
  records         = module.eks_zero.default_ingress_nameservers   # <---
}
```

Or to define one's own Terraform output such as the following:

```
output "cluster_ns" { 
  value = module.eks_zero.default_ingress_nameservers
}
```

```
Outputs:

cluster_ns = [
  "ns-1141.awsdns-14.org",
  "ns-116.awsdns-14.com",
  "ns-1754.awsdns-27.co.uk",
  "ns-544.awsdns-04.net",
]
```


If this seems like an acceptable change, I can add similar outputs to the `gke` and `azurerm` providers.

Thoughts?