### PR TITLE
Add current_config output to all providers

### DIFF
--- a/aws/cluster/output.tf
+++ b/aws/cluster/output.tf
@@ -1,7 +1,3 @@
-output "aks_vnet" {
-  value = module.cluster.aks_vnet
-}
-
 output "current_config" {
   value = module.configuration.merged[terraform.workspace]
 }

--- a/google/cluster/output.tf
+++ b/google/cluster/output.tf
@@ -1,7 +1,3 @@
-output "aks_vnet" {
-  value = module.cluster.aks_vnet
-}
-
 output "current_config" {
   value = module.configuration.merged[terraform.workspace]
 }

--- a/kind/cluster/output.tf
+++ b/kind/cluster/output.tf
@@ -1,7 +1,3 @@
-output "aks_vnet" {
-  value = module.cluster.aks_vnet
-}
-
 output "current_config" {
   value = module.configuration.merged[terraform.workspace]
 }


### PR DESCRIPTION
In PR #135, we had a discussion about adding outputs to the Kubestack `cluster` module. This PR adds an output containing the merged configuration for the current workspace. This should allow users to more easily extend Kubestack projects with additional resources, and to manage configuration variables for those additional resources using the same inheritance behavior as the rest of Kubestack.