### PR TITLE
Typo fixes

### DIFF
--- a/kind/_modules/kind/variables.tf
+++ b/kind/_modules/kind/variables.tf
@@ -20,7 +20,7 @@ variable "metadata_labels" {
 
 variable "extra_nodes" {
   type        = string
-  description = "Comma seperated list of node roles. E.g. 'control-plan,worker'"
+  description = "Comma-separated list of node roles. E.g. 'control-plane,worker'"
 }
 
 variable "http_port" {

--- a/quickstart/src/configurations/aks/config.auto.tfvars
+++ b/quickstart/src/configurations/aks/config.auto.tfvars
@@ -17,12 +17,12 @@ clusters = {
       # The Azure resource group to use
       resource_group = ""
 
-      # CNI/Advanced networking configuration parameters. 
+      # CNI/Advanced networking configuration parameters.
       # Leave commented for default 'kubenet' networking
       # vnet_address_space       = "10.16.0.0/12"  # accepts multiple comma-separated values
       # subnet_address_prefixes  = "10.18.0.0/16"  # accepts multiple comma-separated values
       # subnet_service_endpoints = null            # accepts multiple comma-separated values
-    
+
       # network_plugin           = "azure"
       # network_policy           = "azure"
       # service_cidr             = "10.0.0.0/16"
@@ -30,10 +30,10 @@ clusters = {
       # max_pods                 = 30
     }
 
-    # ops environment, inherrits from apps
+    # ops environment, inherits from apps
     ops = {}
 
-    # loc environment, inherrits from apps
+    # loc environment, inherits from apps
     loc = {}
   }
 }

--- a/quickstart/src/configurations/eks/config.auto.tfvars
+++ b/quickstart/src/configurations/eks/config.auto.tfvars
@@ -19,7 +19,7 @@ clusters = {
       cluster_min_size         = "1"
       cluster_max_size         = "3"
 
-      # Comma seperated list of zone names to deploy worker nodes in
+      # Comma-separated list of zone names to deploy worker nodes in
       # EKS requires a min. of 2 zones
       # Must match region set in provider
       # e.g. cluster_availability_zones = "eu-west-1a,eu-west-1b,eu-west-1c"
@@ -27,10 +27,10 @@ clusters = {
       cluster_availability_zones = ""
     }
 
-    # ops environment, inherrits from apps
+    # ops environment, inherits from apps
     ops = {}
 
-    # loc environment, inherrits from apps
+    # loc environment, inherits from apps
     loc = {
       node_image = "ghcr.io/kbst/kind-eks-d:v1.18.9-kbst.1"
     }

--- a/quickstart/src/configurations/gke/config.auto.tfvars
+++ b/quickstart/src/configurations/gke/config.auto.tfvars
@@ -26,17 +26,17 @@ clusters = {
       # The Google cloud region to deploy the clusters in
       region = ""
 
-      # Comma seperated list of zone names to deploy worker nodes in.
+      # Comma-separated list of zone names to deploy worker nodes in.
       # Must match region above.
       # e.g. cluster_node_locations = "europe-west3-a,europe-west3-b,europe-west3-c"
       # FIXME: Use actual list when TF 0.12 finally supports heterogeneous maps
       cluster_node_locations = ""
     }
 
-    # ops environment, inherrits from apps
+    # ops environment, inherits from apps
     ops = {}
 
-    # loc environment, inherrits from apps
+    # loc environment, inherits from apps
     loc = {}
   }
 }

--- a/quickstart/src/configurations/kind/config.auto.tfvars
+++ b/quickstart/src/configurations/kind/config.auto.tfvars
@@ -5,9 +5,9 @@ clusters = {
       name_prefix = "kind"
       base_domain = "infra.127.0.0.1.xip.io"
 
-      # clusters always have at least one control-plan node
+      # clusters always have at least one control-plane node
       # uncommenting extra_nodes below will give you a cluster
-      # with 3 control-plan nodes and 3 worker nodes
+      # with 3 control-plane nodes and 3 worker nodes
       # extra_nodes = "control-plane,control-plane,worker,worker,worker"
     }
 

--- a/quickstart/src/configurations/multi-cloud/config.auto.tfvars
+++ b/quickstart/src/configurations/multi-cloud/config.auto.tfvars
@@ -44,7 +44,7 @@ clusters = {
       cluster_min_size         = "1"
       cluster_max_size         = "3"
 
-      # Comma seperated list of zone names to deploy worker nodes in
+      # Comma-separated list of zone names to deploy worker nodes in
       # EKS requires a min. of 2 zones
       # Must match region set in provider
       # e.g. cluster_availability_zones = "eu-west-1a,eu-west-1b,eu-west-1c"
@@ -91,7 +91,7 @@ clusters = {
       # The Google cloud region to deploy the clusters in
       region = ""
 
-      # Comma seperated list of zone names to deploy worker nodes in.
+      # Comma-separated list of zone names to deploy worker nodes in.
       # Must match region above.
       # e.g. cluster_node_locations = "europe-west3-a,europe-west3-b,europe-west3-c"
       # FIXME: Use actual list when TF 0.12 finally supports heterogeneous maps


### PR DESCRIPTION
### Changes

Remove some whitespace, fix spelling errors

### Questions

The following snippet seems contradictory:

```
variable "metadata_fqdn" {
  type        = string
  description = "DNS name of the zone. Requires dot at the end. E.g. example.com"
}
```

Should this be
```
DNS name of the zone. Requires dot at the end. E.g. example.com.  # <- with trailing dot
```

or
```
DNS name of the zone. E.g. example.com  # <- without trailing dot
```
?

Some search results suggest that the dot is actually appended elsewhere:

```
google/_modules/gke/ingress.tf:	  dns_name = "${var.metadata_fqdn}."
aws/_modules/eks/ingress.tf:	  name = "${var.metadata_fqdn}."
```