### PR TITLE
Use >= instead of ~> for required_provider versions

### DIFF
--- a/aws/_modules/eks/versions.tf
+++ b/aws/_modules/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.9.0"
+      version = ">= 3.9.0"
     }
 
     external = {


### PR DESCRIPTION
Currently, the caller of the `terraform-kubestack` module is forced to use version `3.9.0` of the aws provider. This PR allows the caller of the module to use any version above `3.9.0`, as recommended by the [Terraform documentation](https://www.terraform.io/docs/modules/providers.html#provider-version-constraints-in-modules), which says:

> If you are writing a shared Terraform module, constrain only the minimum required provider version using a >= constraint. This should specify the minimum version containing the features your module relies on, and thus allow a user of your module to potentially select a newer provider version if other features are needed by other parts of their overall configuration.