### PR TITLE
AKS: SKU tier and node_labels to default_pool

### DIFF
--- a/azurerm/_modules/aks/main.tf
+++ b/azurerm/_modules/aks/main.tf
@@ -7,6 +7,7 @@ resource "azurerm_kubernetes_cluster" "current" {
   location            = data.azurerm_resource_group.current.location
   resource_group_name = data.azurerm_resource_group.current.name
   dns_prefix          = var.dns_prefix
+  sku_tier            = var.sku_tier
 
   role_based_access_control {
     enabled = true

--- a/azurerm/_modules/aks/main.tf
+++ b/azurerm/_modules/aks/main.tf
@@ -31,6 +31,7 @@ resource "azurerm_kubernetes_cluster" "current" {
 
     vnet_subnet_id = var.network_plugin == "azure" ? azurerm_subnet.current[0].id : null
     max_pods       = var.max_pods
+    node_labels    = var.metadata_labels
   }
 
   network_profile {

--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -148,3 +148,9 @@ variable "user_assigned_identity_id" {
   description = "ID of the UserAssigned identity to use."
   default     = null
 }
+
+variable "sku_tier" {
+  type        = string
+  description = "The SKU tier to use for the cluster. Possible values are 'Free' and 'Paid'. Defaults to 'Free'."
+  default     = "Free"
+}

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -17,6 +17,8 @@ locals {
 
   dns_prefix = lookup(local.cfg, "dns_prefix", "api")
 
+  sku_tier = lookup(local.cfg, "sku_tier", "Free")
+
   vnet_address_space      = split(",", lookup(local.cfg, "vnet_address_space", "10.0.0.0/8"))
   subnet_address_prefixes = split(",", lookup(local.cfg, "subnet_address_prefixes", "10.1.0.0/16"))
 

--- a/azurerm/cluster/main.tf
+++ b/azurerm/cluster/main.tf
@@ -27,6 +27,8 @@ module "cluster" {
 
   dns_prefix = local.dns_prefix
 
+  sku_tier = local.sku_tier
+
   vnet_address_space       = local.vnet_address_space
   subnet_address_prefixes  = local.subnet_address_prefixes
   subnet_service_endpoints = local.subnet_service_endpoints


### PR DESCRIPTION
Quickly searching did not find anything similar on either google or EKS for the `sku_tier`, so just added this one.

Also forward the already present and similarly used (at least in EKS) `var.metadata_labels` to populate default pool `node_labels`