### PR TITLE
Revert "Re-use the metadata_labels variable for node_labels"

### DIFF
--- a/azurerm/_modules/aks/main.tf
+++ b/azurerm/_modules/aks/main.tf
@@ -31,7 +31,6 @@ resource "azurerm_kubernetes_cluster" "current" {
 
     vnet_subnet_id = var.network_plugin == "azure" ? azurerm_subnet.current[0].id : null
     max_pods       = var.max_pods
-    node_labels    = var.metadata_labels
   }
 
   network_profile {


### PR DESCRIPTION
This reverts commit 170bf26f3fb403c50d0613432cc6ca30ee49c89b, because adding
the node_labels to the default node pool requires a destroy and re-create on
the AKS cluster.

This is likely due to the node_pool using the legacy `default_node_pool`
block of the `azurerm_kubernetes_cluster` resource. Must migrate to using
a `azurerm_kubernetes_cluster_node_pool`. Will tackle this as part of
revamping node pools support in general.

Opening an issue to track this:

https://github.com/kbst/terraform-kubestack/issues/172