### PR TITLE
Fix AKS vnet names #170

### DIFF
--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -23,6 +23,12 @@ variable "resource_group" {
   description = "Resource group to use for the cluster."
 }
 
+variable "legacy_vnet_name" {
+  type        = bool
+  description = "Wheter to use the legacy vnet and subnet names."
+  default     = false
+}
+
 variable "vnet_address_space" {
   type        = list(string)
   description = "Address space for the virtual network."

--- a/azurerm/_modules/aks/vnet.tf
+++ b/azurerm/_modules/aks/vnet.tf
@@ -2,7 +2,7 @@
 resource "azurerm_virtual_network" "current" {
   count = var.network_plugin == "azure" ? 1 : 0
 
-  name                = "vnet-aks-${terraform.workspace}-cluster"
+  name                = var.legacy_vnet_name ? "vnet-aks-${terraform.workspace}-cluster" : var.metadata_name
   address_space       = var.vnet_address_space
   resource_group_name = data.azurerm_resource_group.current.name
   location            = data.azurerm_resource_group.current.location
@@ -11,7 +11,7 @@ resource "azurerm_virtual_network" "current" {
 resource "azurerm_subnet" "current" {
   count = var.network_plugin == "azure" ? 1 : 0
 
-  name                 = "aks-node-subnet"
+  name                 = var.legacy_vnet_name ? "aks-node-subnet" : "${var.metadata_name}-${var.default_node_pool_name}-node-pool"
   address_prefixes     = var.subnet_address_prefixes
   resource_group_name  = data.azurerm_resource_group.current.name
   virtual_network_name = azurerm_virtual_network.current[0].name

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -19,6 +19,7 @@ locals {
 
   sku_tier = lookup(local.cfg, "sku_tier", "Free")
 
+  legacy_vnet_name        = lookup(local.cfg, "legacy_vnet_name", false)
   vnet_address_space      = split(",", lookup(local.cfg, "vnet_address_space", "10.0.0.0/8"))
   subnet_address_prefixes = split(",", lookup(local.cfg, "subnet_address_prefixes", "10.1.0.0/16"))
 

--- a/azurerm/cluster/main.tf
+++ b/azurerm/cluster/main.tf
@@ -29,6 +29,7 @@ module "cluster" {
 
   sku_tier = local.sku_tier
 
+  legacy_vnet_name         = local.legacy_vnet_name
   vnet_address_space       = local.vnet_address_space
   subnet_address_prefixes  = local.subnet_address_prefixes
   subnet_service_endpoints = local.subnet_service_endpoints

--- a/tests/config.auto.tfvars
+++ b/tests/config.auto.tfvars
@@ -43,6 +43,8 @@ clusters = {
       resource_group = "terraform-kubestack-testing"
       name_prefix    = "kbstacctest"
       base_domain    = "infra.serverwolken.de"
+
+      network_plugin = "azure"
     }
 
     # Settings for Ops-cluster


### PR DESCRIPTION
The vnet name did not use the metadata_name var, and the code
used to generate the name did only include the workspace.

This meant it supported multiple environments in the same Azure
resource group, but not multiple clusters per environment in
the same resource group.

With this commit, the vnet uses the metadata_name variable and
the subnet will include the name of the node pool.

Since changing the vnet and subnet names would require a
destroy and re-create plan, existing users can keep the old
names by setting `legacy_vnet_name = true`.