### PR TITLE
Fix configuration module inheritance #176

### DIFF
--- a/common/configuration/outputs.tf
+++ b/common/configuration/outputs.tf
@@ -3,15 +3,17 @@ locals {
     (var.base_key) = var.configuration[var.base_key]
   }
 
+  base_config = local.base[var.base_key]
+
   overlays = {
     # include all envs but the base_key in overlays
     for env_key, env in var.configuration :
     env_key => {
-      # loop through all config keys in base_key environment
+      # loop through all config keys in base_key environment and current env
       # if current env has that key, use the value from current env
       # if not, use the value from the base_key environment
-      for key, value in var.configuration[var.base_key] :
-      key => lookup(env, key, null) != null ? env[key] : value
+      for key in setunion(keys(env), keys(local.base_config)) :
+      key => lookup(env, key, null) != null ? env[key] : local.base_config[key]
     }
     if env_key != var.base_key
   }


### PR DESCRIPTION
The [change to support maps of objects][1], not just maps of strings, introduced a regression. Keys not set in the base environment, but set in an environment that inherits from base were lost.

Previously ops inherited from apps and could overwrite values set in apps as well as add new key value pairs to the ops env.

This commit fixes the regression by looping through a set of all keys from both the environments to be merged.

[1]: https://github.com/kbst/terraform-kubestack/commit/22b0eb8c9439d8f4f2480c04f59acfeba54e6be9