### PR TITLE
Speed up dist with smaller dist-helper stage

### DIFF
--- a/oci/Dockerfile
+++ b/oci/Dockerfile
@@ -153,7 +153,7 @@ CMD bash
 #
 #
 # Build starters and provider cache
-FROM final-base as dist-helper
+FROM final-base as dist-helper-build
 
 COPY common /common
 
@@ -195,6 +195,13 @@ RUN set -e &&\
 
 RUN cd build_artifacts &&\
     pipenv run python dist.py compress
+
+#
+#
+# Dist artifacts
+FROM alpine as dist-helper
+
+COPY --from=dist-helper-build /quickstart/_dist /quickstart/_dist
 
 
 #


### PR DESCRIPTION
Caching to a registry image requires running the build in a
container using buildkit. To be able to run the image and
copy the artifacts out of the container using docker cp
the image needs to be exported from the build container to
the host.

This additional build stage means, the image that is exported
to the host is much smaller by not including the Python and
Terraform caches.