### PR TITLE
Added ability to set cluster version on EKS

### DIFF
--- a/aws/_modules/eks/master.tf
+++ b/aws/_modules/eks/master.tf
@@ -12,5 +12,7 @@ resource "aws_eks_cluster" "current" {
     aws_iam_role_policy_attachment.master_service_policy,
   ]
 
+  version = var.cluster_version
+
   enabled_cluster_log_types = var.enabled_cluster_log_types
 }

--- a/aws/_modules/eks/variables.tf
+++ b/aws/_modules/eks/variables.tf
@@ -84,3 +84,9 @@ variable "disable_openid_connect_provider" {
   type        = bool
   description = "Whether to disable the OpenID connect provider."
 }
+
+variable "cluster_version" {
+  type        = string
+  default     = null
+  description = "The version of the cluster (defaults to latest available)"
+}

--- a/aws/cluster/configuration.tf
+++ b/aws/cluster/configuration.tf
@@ -24,6 +24,8 @@ locals {
 
   cluster_min_size = local.cfg["cluster_min_size"]
 
+  cluster_version = lookup(local.cfg, "cluster_version", null)
+
   worker_root_device_volume_size = lookup(local.cfg, "worker_root_device_volume_size", null)
   worker_root_device_encrypted   = lookup(local.cfg, "worker_root_device_encrypted", null)
 

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -23,6 +23,7 @@ module "cluster" {
   desired_capacity   = local.cluster_desired_capacity
   max_size           = local.cluster_max_size
   min_size           = local.cluster_min_size
+  cluster_version    = local.cluster_version
 
   root_device_encrypted   = local.worker_root_device_encrypted
   root_device_volume_size = local.worker_root_device_volume_size


### PR DESCRIPTION
Signed-off-by: Spazzy <brendankamp757@gmail.com>

# Changelog

- Gives the ability to set the version of the EKS cluster
- Defaults to the latest version if no version is specified

Fix: https://github.com/kbst/terraform-kubestack/issues/164