### PR TITLE
Update Terraform version to v0.15.1

### DIFF
--- a/oci/Dockerfile
+++ b/oci/Dockerfile
@@ -30,7 +30,7 @@ ARG KUBECTL_VERSION=v1.21.0
 ARG KUSTOMIZE_VERSION=v3.9.2
 
 # https://www.terraform.io/downloads.html
-ARG TERRAFORM_VERSION=0.15.0
+ARG TERRAFORM_VERSION=0.15.1
 
 RUN echo "KUBECTL_VERSION: ${KUBECTL_VERSION}" \
     && curl -Lo /opt/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl \


### PR DESCRIPTION
In response to a potential disclosure of sensitive information
via the Codecov security incident, Hashicorp has rotated the
key used to sign providers. This commit updates Terraform to
v0.15.1 which uses the new key for validation.

More information: https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512