### PR TITLE
Generalize for different AWS partitions

### DIFF
--- a/aws/_modules/eks/openid_connect.tf
+++ b/aws/_modules/eks/openid_connect.tf
@@ -1,7 +1,3 @@
-data "aws_partition" "current" {
-  count = var.disable_openid_connect_provider == false ? 1 : 0
-}
-
 data "tls_certificate" "current" {
   count = var.disable_openid_connect_provider == false ? 1 : 0
 
@@ -11,7 +7,7 @@ data "tls_certificate" "current" {
 resource "aws_iam_openid_connect_provider" "current" {
   count = var.disable_openid_connect_provider == false ? 1 : 0
 
-  client_id_list  = ["sts.${data.aws_partition.current[0].dns_suffix}"]
+  client_id_list  = ["sts.${data.aws_partition.current.dns_suffix}"]
   thumbprint_list = [data.tls_certificate.current[0].certificates[0].sha1_fingerprint]
   url             = aws_eks_cluster.current.identity[0].oidc[0].issuer
 }

--- a/aws/_modules/eks/provider.tf
+++ b/aws/_modules/eks/provider.tf
@@ -1,3 +1,5 @@
+data "aws_partition" "current" {}
+
 data "aws_caller_identity" "current" {
 }
 
@@ -10,7 +12,7 @@ locals {
   caller_id_arn_type = replace(element(local.resource_split, 0), "assumed-role", "role")
   caller_id_name     = element(local.resource_split, 1)
 
-  caller_id_arn = "arn:aws:iam::${data.aws_arn.current.account}:${local.caller_id_arn_type}/${local.caller_id_name}"
+  caller_id_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_arn.current.account}:${local.caller_id_arn_type}/${local.caller_id_name}"
 }
 
 data "aws_eks_cluster_auth" "current" {

--- a/aws/_modules/eks/roles_master.tf
+++ b/aws/_modules/eks/roles_master.tf
@@ -19,12 +19,12 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "master_cluster_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSClusterPolicy"
   role       = aws_iam_role.master.name
 }
 
 resource "aws_iam_role_policy_attachment" "master_service_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSServicePolicy"
   role       = aws_iam_role.master.name
 }
 

--- a/aws/_modules/eks/roles_worker.tf
+++ b/aws/_modules/eks/roles_worker.tf
@@ -19,17 +19,17 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "node_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
   role       = aws_iam_role.node.name
 }
 
 resource "aws_iam_role_policy_attachment" "node_cni_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
   role       = aws_iam_role.node.name
 }
 
 resource "aws_iam_role_policy_attachment" "node_container_registry_ro" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   role       = aws_iam_role.node.name
 }
 


### PR DESCRIPTION
With the AWS partition fixed to 'aws', you will get errors about policy resources not
being found if you are in other partitions such as aws-cn or aws-us-gov. This replaces
the hard-coded partition with the actual partition so that policy ARNs have the right
parameters.