### PR TITLE
Added limit for service account name GKE

### DIFF
--- a/google/_modules/gke/service_account.tf
+++ b/google/_modules/gke/service_account.tf
@@ -1,5 +1,5 @@
 resource "google_service_account" "current" {
-  account_id = var.metadata_name
+  account_id = substr(var.metadata_name, 0, 30)
   project    = var.project
 }
 


### PR DESCRIPTION
Signed-off-by: Spazzy <brendankamp757@gmail.com>

# Changelog

- added a substring that will limit the name of the service account to 30 characters, (google requires names to match this regexp `^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])`)

fixes: https://github.com/kbst/terraform-kubestack/issues/145