### PR TITLE
added configurable azure policy agent

### DIFF
--- a/azurerm/_modules/aks/main.tf
+++ b/azurerm/_modules/aks/main.tf
@@ -64,6 +64,10 @@ resource "azurerm_kubernetes_cluster" "current" {
   }
 
   addon_profile {
+    azure_policy {
+      enabled = var.enable_azure_policy_agent
+    }
+
     kube_dashboard {
       enabled = false
     }

--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -133,6 +133,12 @@ variable "disable_default_ingress" {
   description = "Whether to disable the default ingress."
 }
 
+variable "enable_azure_policy_agent" {
+  type        = bool
+  description = "whether to deploy the Azure policy agent to the cluster"
+  default     = false 
+}
+
 variable "service_principal_end_date_relative" {
   type        = string
   description = "Relative time in hours for which the service principal password is valid. Defaults to 1 year."

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -47,6 +47,8 @@ locals {
 
   disable_default_ingress = lookup(local.cfg, "disable_default_ingress", false)
 
+  enable_azure_policy_agent = lookup(local.cfg, "enable_azure_policy_agent", false)
+
   service_principal_end_date_relative = lookup(local.cfg, "service_principal_end_date_relative", "8766h")
 
   disable_managed_identities = lookup(local.cfg, "disable_managed_identities", false)

--- a/azurerm/cluster/main.tf
+++ b/azurerm/cluster/main.tf
@@ -54,6 +54,8 @@ module "cluster" {
 
   disable_default_ingress = local.disable_default_ingress
 
+  enable_azure_policy_agent = local.enable_azure_policy_agent
+
   service_principal_end_date_relative = local.service_principal_end_date_relative
 
   disable_managed_identities = local.disable_managed_identities


### PR DESCRIPTION
After experimenting with enabling the azure policy agent on a kubestack-built cluster, we found that kubestack was triggering a rebuild on every apply in an attempt to remove the `azure_policy` block.

This PR adds that block, along with a configuration parameter to allow users to enable the policy agent in their cluster module by adding

`enable_azure_policy_agent = true`

Omitting it will still add the `azure_policy` block, but with a default value of `false`