### PR TITLE
GKE: adds ability to set endpoint independent mapping to nat gateway

### DIFF
--- a/google/_modules/gke/network.tf
+++ b/google/_modules/gke/network.tf
@@ -22,8 +22,10 @@ resource "google_compute_router_nat" "nat" {
   region  = google_compute_router.current[0].region
   router  = google_compute_router.current[0].name
 
-  nat_ip_allocate_option             = "AUTO_ONLY"
-  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  enable_endpoint_independent_mapping = var.cloud_nat_endpoint_independent_mapping
+  min_ports_per_vm                    = var.cloud_nat_min_ports_per_vm
+  nat_ip_allocate_option              = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat  = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 
   log_config {
     enable = true

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -124,6 +124,16 @@ variable "enable_cloud_nat" {
   description = "Whether to enable cloud nat and allow internet access for private nodes."
 }
 
+variable "cloud_nat_endpoint_independent_mapping" {
+  type        = bool
+  description = "Whether to enable cloud nat endpoint independent mapping"
+}
+
+variable "cloud_nat_min_ports_per_vm" {
+  type        = number
+  description = "The min amount of ports per VM allowed for NAT mapping"
+}
+
 variable "disable_workload_identity" {
   description = "Wheter to disable workload identity support."
   type        = bool

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -58,7 +58,9 @@ locals {
   master_cidr_block    = lookup(local.cfg, "master_cidr_block", "172.16.0.32/28")
 
   # by default include cloud_nat when private nodes are enabled
-  enable_cloud_nat = lookup(local.cfg, "enable_cloud_nat", local.enable_private_nodes)
+  enable_cloud_nat                       = lookup(local.cfg, "enable_cloud_nat", local.enable_private_nodes)
+  cloud_nat_endpoint_independent_mapping = lookup(local.cfg, "cloud_nat_enable_endpoint_independent_mapping", null)
+  cloud_nat_min_ports_per_vm             = lookup(local.cfg, "cloud_nat_min_ports_per_vm", null)
 
   disable_workload_identity             = lookup(local.cfg, "disable_workload_identity", false)
   default_node_workload_metadata_config = tobool(local.disable_workload_identity) == false ? "GKE_METADATA_SERVER" : "UNSPECIFIED"

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -46,9 +46,12 @@ module "cluster" {
 
   disable_default_ingress = local.disable_default_ingress
 
-  enable_private_nodes = local.enable_private_nodes
-  master_cidr_block    = local.master_cidr_block
-  enable_cloud_nat     = local.enable_cloud_nat
+  enable_private_nodes                   = local.enable_private_nodes
+  master_cidr_block                      = local.master_cidr_block
+  enable_cloud_nat                       = local.enable_cloud_nat
+  cloud_nat_endpoint_independent_mapping = local.cloud_nat_endpoint_independent_mapping
+
+  cloud_nat_min_ports_per_vm = local.cloud_nat_min_ports_per_vm
 
   disable_workload_identity     = local.disable_workload_identity
   node_workload_metadata_config = local.node_workload_metadata_config


### PR DESCRIPTION
Signed-off-by: Spazzy <brendan@pento.io>

# Changelog

- adds ability to set the value `cloud_nat_enable_endpoint_independent_mapping`
- adds ability to set  the value `cloud_nat_min_ports_per_vm`

Both values default to Google defaults by setting them to null

Fixes: https://github.com/kbst/terraform-kubestack/issues/212