### PR TITLE
EKS: Default to separate control and node pool subnets

### DIFF
--- a/aws/_modules/eks/node_pool.tf
+++ b/aws/_modules/eks/node_pool.tf
@@ -9,7 +9,7 @@ module "node_pool" {
 
   role_arn = aws_iam_role.node.arn
 
-  subnet_ids = aws_subnet.current.*.id
+  subnet_ids = var.vpc_legacy_node_subnets ? aws_subnet.current.*.id : aws_subnet.node_pool.*.id
 
   instance_type = var.instance_type
   desired_size  = var.desired_capacity

--- a/aws/_modules/eks/variables.tf
+++ b/aws/_modules/eks/variables.tf
@@ -23,8 +23,24 @@ variable "vpc_cidr" {
   type        = string
 }
 
-variable "vpc_subnet_newbits" {
-  description = "CIDR to use for the VPC."
+variable "vpc_legacy_node_subnets" {
+  description = "Whether to keep the legacy node subnets for backwards compatibility."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_control_subnet_newbits" {
+  description = "CIDR newbits to use for the control plane subnets."
+  type        = string
+}
+
+variable "vpc_node_subnet_newbits" {
+  description = "CIDR newbits to use for the node pool subnets."
+  type        = string
+}
+
+variable "vpc_node_subnet_number_offset" {
+  description = "CIDR subnet number offset to use for the node pool subnets."
   type        = string
 }
 

--- a/aws/_modules/eks/vpc.tf
+++ b/aws/_modules/eks/vpc.tf
@@ -8,7 +8,18 @@ resource "aws_subnet" "current" {
   count = length(var.availability_zones)
 
   availability_zone       = var.availability_zones[count.index]
-  cidr_block              = cidrsubnet(aws_vpc.current.cidr_block, var.vpc_subnet_newbits, count.index)
+  cidr_block              = cidrsubnet(aws_vpc.current.cidr_block, var.vpc_control_subnet_newbits, count.index)
+  vpc_id                  = aws_vpc.current.id
+  map_public_ip_on_launch = true
+
+  tags = local.eks_metadata_tags
+}
+
+resource "aws_subnet" "node_pool" {
+  count = var.vpc_legacy_node_subnets ? 0 : length(var.availability_zones)
+
+  availability_zone       = var.availability_zones[count.index]
+  cidr_block              = cidrsubnet(aws_vpc.current.cidr_block, var.vpc_node_subnet_newbits, var.vpc_node_subnet_number_offset + count.index)
   vpc_id                  = aws_vpc.current.id
   map_public_ip_on_launch = true
 
@@ -36,5 +47,12 @@ resource "aws_route_table_association" "current" {
   count = length(var.availability_zones)
 
   subnet_id      = aws_subnet.current[count.index].id
+  route_table_id = aws_route_table.current.id
+}
+
+resource "aws_route_table_association" "node_pool" {
+  count = var.vpc_legacy_node_subnets ? 0 : length(var.availability_zones)
+
+  subnet_id      = aws_subnet.node_pool[count.index].id
   route_table_id = aws_route_table.current.id
 }

--- a/aws/cluster/configuration.tf
+++ b/aws/cluster/configuration.tf
@@ -16,8 +16,11 @@ locals {
   cluster_availability_zones_lookup = lookup(local.cfg, "cluster_availability_zones", "")
   cluster_availability_zones        = split(",", local.cluster_availability_zones_lookup)
 
-  cluster_vpc_cidr           = lookup(local.cfg, "cluster_vpc_cidr", "10.0.0.0/16")
-  cluster_vpc_subnet_newbits = lookup(local.cfg, "cluster_vpc_subnet_newbits", "8")
+  cluster_vpc_cidr                      = lookup(local.cfg, "cluster_vpc_cidr", "10.0.0.0/16")
+  cluster_vpc_control_subnet_newbits    = lookup(local.cfg, "cluster_vpc_control_subnet_newbits", "8")
+  cluster_vpc_node_subnet_newbits       = lookup(local.cfg, "cluster_vpc_node_subnet_newbits", "4")
+  cluster_vpc_node_subnet_number_offset = lookup(local.cfg, "cluster_vpc_node_subnet_number_offset", "1")
+  cluster_vpc_legacy_node_subnets       = lookup(local.cfg, "cluster_vpc_legacy_node_subnets", false)
 
   cluster_instance_type = local.cfg["cluster_instance_type"]
 

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -19,8 +19,12 @@ module "cluster" {
   metadata_labels = module.cluster_metadata.labels
 
   availability_zones = local.cluster_availability_zones
-  vpc_cidr           = local.cluster_vpc_cidr
-  vpc_subnet_newbits = local.cluster_vpc_subnet_newbits
+
+  vpc_cidr                      = local.cluster_vpc_cidr
+  vpc_control_subnet_newbits    = local.cluster_vpc_control_subnet_newbits
+  vpc_node_subnet_newbits       = local.cluster_vpc_node_subnet_newbits
+  vpc_node_subnet_number_offset = local.cluster_vpc_node_subnet_number_offset
+  vpc_legacy_node_subnets       = local.cluster_vpc_legacy_node_subnets
 
   instance_type    = local.cluster_instance_type
   desired_capacity = local.cluster_desired_capacity


### PR DESCRIPTION
 * use /24 per AZ for control plane only
 * use /20 per AZ for node pool
 * users can configure both
 * existing clusters share /24 per AZ across
   control plane and nodes, `cluster_vpc_legacy_node_subnets`
   is available to keep control plane subnets shared with
   node pool for backwards compatibility