### PR TITLE
adds manual IP addresses to the NAT gateway

### DIFF
--- a/google/_modules/gke/network.tf
+++ b/google/_modules/gke/network.tf
@@ -4,6 +4,15 @@ resource "google_compute_network" "current" {
   auto_create_subnetworks = "true"
 }
 
+resource "google_compute_address" "nat" {
+  count = var.enable_cloud_nat ? var.cloud_nat_ip_count : 0
+
+  region  = google_container_cluster.current.location
+  project = var.project
+
+  name = "nat-${var.metadata_name}-${count.index}"
+}
+
 resource "google_compute_router" "current" {
   count = var.enable_cloud_nat ? 1 : 0
 
@@ -24,8 +33,9 @@ resource "google_compute_router_nat" "nat" {
 
   enable_endpoint_independent_mapping = var.cloud_nat_endpoint_independent_mapping
   min_ports_per_vm                    = var.cloud_nat_min_ports_per_vm
-  nat_ip_allocate_option              = "AUTO_ONLY"
+  nat_ip_allocate_option              = var.cloud_nat_ip_count > 0 ? "MANUAL_ONLY" : "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat  = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  nat_ips                             = var.cloud_nat_ip_count > 0 ? google_compute_address.nat.*.self_link : null
 
   log_config {
     enable = true

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -134,6 +134,11 @@ variable "cloud_nat_min_ports_per_vm" {
   description = "The min amount of ports per VM allowed for NAT mapping"
 }
 
+variable "cloud_nat_ip_count" {
+  type        = number
+  description = "The amount of IP addresses to attach to the NAT gateway, changes NAT to use MANUAL_ONLY"
+}
+
 variable "disable_workload_identity" {
   description = "Wheter to disable workload identity support."
   type        = bool

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -61,6 +61,7 @@ locals {
   enable_cloud_nat                       = lookup(local.cfg, "enable_cloud_nat", local.enable_private_nodes)
   cloud_nat_endpoint_independent_mapping = lookup(local.cfg, "cloud_nat_enable_endpoint_independent_mapping", null)
   cloud_nat_min_ports_per_vm             = lookup(local.cfg, "cloud_nat_min_ports_per_vm", null)
+  cloud_nat_ip_count                     = lookup(local.cfg, "cloud_nat_ip_count", 0)
 
   disable_workload_identity             = lookup(local.cfg, "disable_workload_identity", false)
   default_node_workload_metadata_config = tobool(local.disable_workload_identity) == false ? "GKE_METADATA_SERVER" : "UNSPECIFIED"

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -50,6 +50,7 @@ module "cluster" {
   master_cidr_block                      = local.master_cidr_block
   enable_cloud_nat                       = local.enable_cloud_nat
   cloud_nat_endpoint_independent_mapping = local.cloud_nat_endpoint_independent_mapping
+  cloud_nat_ip_count                     = local.cloud_nat_ip_count
 
   cloud_nat_min_ports_per_vm = local.cloud_nat_min_ports_per_vm
 


### PR DESCRIPTION
Signed-off-by: Spazzy <brendan@pento.io>

# Changelog

* Adds variable `cloud_nat_ip_count` which changes the NAT gateway to create external IP addresses and attach them Manually to the Nat gateway instead of the NAT automatically creating it.
* If `cluster_nat_ip_count` it will default to using `AUTO_ONLY`

fixes:  https://github.com/kbst/terraform-kubestack/issues/218