### PR TITLE
Add support for NLBs to AWS Ingress

### DIFF
--- a/aws/cluster/elb-dns/variables.tf
+++ b/aws/cluster/elb-dns/variables.tf
@@ -12,3 +12,9 @@ variable "metadata_fqdn" {
   type        = string
   description = "Cluster module FQDN."
 }
+
+variable "using_nlb" {
+  type        = bool
+  default     = false
+  description = "Whether the ingress uses NLB or classic ELB."
+}


### PR DESCRIPTION
I'm running istio and changing the ingress from classic ELB to NLB. This breaks this module, as `aws_elb_hosted_zone_id` doesn't support NLB: https://github.com/hashicorp/terraform-provider-aws/issues/7988

This PR implements the workaround described in the issue with an optional flag.

We could also just use the workaround for all cases, but it seems to me that `aws_lb` doesn't support classic ELBs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb