### PR TITLE
Expose cluster endpoint access configuration options to enable restricting network access to the k8s API endpoint

### DIFF
--- a/aws/_modules/eks/master.tf
+++ b/aws/_modules/eks/master.tf
@@ -3,8 +3,11 @@ resource "aws_eks_cluster" "current" {
   role_arn = aws_iam_role.master.arn
 
   vpc_config {
-    security_group_ids = [aws_security_group.masters.id]
-    subnet_ids         = aws_subnet.current.*.id
+    security_group_ids      = [aws_security_group.masters.id]
+    subnet_ids              = aws_subnet.current.*.id
+    endpoint_private_access = var.cluster_endpoint_private_access
+    endpoint_public_access  = var.cluster_endpoint_public_access
+    public_access_cidrs     = var.cluster_public_access_cidrs
   }
 
   depends_on = [

--- a/aws/_modules/eks/variables.tf
+++ b/aws/_modules/eks/variables.tf
@@ -120,3 +120,21 @@ variable "cluster_version" {
   default     = null
   description = "The version of the cluster (defaults to latest available)"
 }
+
+variable "cluster_endpoint_private_access" {
+  type        = bool
+  default     = false
+  description = "Whether the Amazon EKS private API server endpoint is enabled (making the kubernetes API endpoint accessible from the internal network)."
+}
+
+variable "cluster_endpoint_public_access" {
+  type        = bool
+  default     = true
+  description = "Whether the Amazon EKS public API server endpoint is enabled (making the kubernetes API endpoint accessible from the public internet)."
+}
+
+variable "cluster_public_access_cidrs" {
+  type        = list(string)
+  default     = null
+  description = "List of CIDR blocks which can access the Amazon EKS public API server endpoint. EKS defaults this to a list with 0.0.0.0/0."
+}

--- a/aws/cluster/configuration.tf
+++ b/aws/cluster/configuration.tf
@@ -48,4 +48,9 @@ locals {
   enabled_cluster_log_types        = split(",", local.enabled_cluster_log_types_lookup)
 
   disable_openid_connect_provider = lookup(local.cfg, "disable_openid_connect_provider", false)
+
+  cluster_endpoint_private_access    = lookup(local.cfg, "cluster_endpoint_private_access", false)
+  cluster_endpoint_public_access     = lookup(local.cfg, "cluster_endpoint_public_access", true)
+  cluster_public_access_cidrs_lookup = lookup(local.cfg, "cluster_public_access_cidrs", null)
+  cluster_public_access_cidrs        = local.cluster_public_access_cidrs_lookup == null ? null : split(",", local.cluster_public_access_cidrs_lookup)
 }

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -45,6 +45,10 @@ module "cluster" {
 
   disable_openid_connect_provider = local.disable_openid_connect_provider
 
+  cluster_endpoint_private_access = local.cluster_endpoint_private_access
+  cluster_endpoint_public_access  = local.cluster_endpoint_public_access
+  cluster_public_access_cidrs     = local.cluster_public_access_cidrs
+
   # cluster module configuration is still map(string)
   # once module_variable_optional_attrs isn't experimental anymore
   # we can migrate cluster module configuration to map(object(...))


### PR DESCRIPTION
Expose cluster endpoint access configuration options to enable restricting network access to the k8s API endpoint.

Based on: https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html#modify-endpoint-access using https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster#vpc_config-arguments

With extra effort on keeping `public_access_cidrs` as `null` if it's not set. This is in order to keep the current behavior if the parameter is not specified:
> EKS defaults this to a list with 0.0.0.0/0. **Terraform will only perform drift detection of its value when present in a configuration.**