### PR TITLE
AKS: Expose only critical addons taint option for default nodepool

### DIFF
--- a/azurerm/_modules/aks/main.tf
+++ b/azurerm/_modules/aks/main.tf
@@ -32,6 +32,8 @@ resource "azurerm_kubernetes_cluster" "current" {
 
     vnet_subnet_id = var.network_plugin == "azure" ? azurerm_subnet.current[0].id : null
     max_pods       = var.max_pods
+
+    only_critical_addons_enabled = var.default_node_pool_only_critical_addons
   }
 
   network_profile {

--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -128,6 +128,12 @@ variable "default_node_pool_os_disk_size_gb" {
   default     = "30"
 }
 
+variable "default_node_pool_only_critical_addons" {
+  type        = bool
+  description = "Enabling will taint default node pool with CriticalAddonsOnly=true:NoSchedule taint. Changing this forces a new resource to be created."
+  default     = false
+}
+
 variable "disable_default_ingress" {
   type        = bool
   description = "Whether to disable the default ingress."

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -41,9 +41,9 @@ locals {
   default_node_pool_max_count           = lookup(local.cfg, "default_node_pool_max_count", "1")
   default_node_pool_node_count          = lookup(local.cfg, "default_node_pool_node_count", "1")
 
-  default_node_pool_vm_size = lookup(local.cfg, "default_node_pool_vm_size", "Standard_B2s")
-
-  default_node_pool_os_disk_size_gb = lookup(local.cfg, "default_node_pool_os_disk_size_gb", "30")
+  default_node_pool_vm_size              = lookup(local.cfg, "default_node_pool_vm_size", "Standard_B2s")
+  default_node_pool_only_critical_addons = lookup(local.cfg, "default_node_pool_only_critical_addons", false)
+  default_node_pool_os_disk_size_gb      = lookup(local.cfg, "default_node_pool_os_disk_size_gb", "30")
 
   disable_default_ingress = lookup(local.cfg, "disable_default_ingress", false)
 

--- a/azurerm/cluster/main.tf
+++ b/azurerm/cluster/main.tf
@@ -49,8 +49,9 @@ module "cluster" {
   default_node_pool_max_count           = local.default_node_pool_max_count
   default_node_pool_node_count          = local.default_node_pool_node_count
 
-  default_node_pool_vm_size         = local.default_node_pool_vm_size
-  default_node_pool_os_disk_size_gb = local.default_node_pool_os_disk_size_gb
+  default_node_pool_only_critical_addons = local.default_node_pool_only_critical_addons
+  default_node_pool_vm_size              = local.default_node_pool_vm_size
+  default_node_pool_os_disk_size_gb      = local.default_node_pool_os_disk_size_gb
 
   disable_default_ingress = local.disable_default_ingress
 
@@ -59,6 +60,6 @@ module "cluster" {
   disable_managed_identities = local.disable_managed_identities
   user_assigned_identity_id  = local.user_assigned_identity_id
 
-  kubernetes_version = local.kubernetes_version
+  kubernetes_version   = local.kubernetes_version
   enable_log_analytics = local.enable_log_analytics
 }


### PR DESCRIPTION
By default, the default AKS node pool (marked as `System`) is still available to run application code, which can have various negative consequences regarding resource drain.

To prevent that, [AKS system pods tolerate](https://docs.microsoft.com/en-us/azure/aks/use-system-pools#system-and-user-node-pools) `CriticalAddonsOnly=true:NoSchedule` taint, and the terraform provider [exposes](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#only_critical_addons_enabled) a bool option for adding this. This simply exposes that same option through the `kubestack` module.

Alternative would be adding this same taint manually afterwards, however with autoscaling new nodes would be created without taints, and the default node pool does not expose other options of adding taints.