### PR TITLE
Expose master_authorized_networks_config option to enable restricting network access to the k8s API endpoint

### DIFF
--- a/google/_modules/gke/cluster.tf
+++ b/google/_modules/gke/cluster.tf
@@ -52,9 +52,19 @@ resource "google_container_cluster" "current" {
     }
   }
 
-  master_authorized_networks_config {
-    count       = var.master_authorized_networks_config_cidr_blocks == null ? 0 : 1
-    cidr_blocks = var.master_authorized_networks_config_cidr_blocks
+  dynamic "master_authorized_networks_config" {
+    for_each = var.master_authorized_networks_config_cidr_blocks == null ? [] : ["1"]
+
+    content {
+      dynamic "cidr_blocks" {
+        for_each = var.master_authorized_networks_config_cidr_blocks
+
+        content {
+          cidr_block   = each.key
+          display_name = "master_authorized_networks_${each.key}"
+        }
+      }
+    }
   }
 
   private_cluster_config {

--- a/google/_modules/gke/cluster.tf
+++ b/google/_modules/gke/cluster.tf
@@ -52,6 +52,11 @@ resource "google_container_cluster" "current" {
     }
   }
 
+  master_authorized_networks_config {
+    count       = var.master_authorized_networks_config_cidr_blocks == null ? 0 : 1
+    cidr_blocks = var.master_authorized_networks_config_cidr_blocks
+  }
+
   private_cluster_config {
     enable_private_nodes    = var.enable_private_nodes
     enable_private_endpoint = false

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -148,3 +148,8 @@ variable "node_workload_metadata_config" {
   description = "How to expose the node metadata to the workload running on the node."
   type        = string
 }
+
+variable "master_authorized_networks_config_cidr_blocks" {
+  description = "The list of CIDR blocks of external networks that can access the Kubernetes cluster master through HTTPS. Setting cidr_blocks to an empty list disallows public access."
+  type        = list(string)
+}

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -66,4 +66,7 @@ locals {
   disable_workload_identity             = lookup(local.cfg, "disable_workload_identity", false)
   default_node_workload_metadata_config = tobool(local.disable_workload_identity) == false ? "GKE_METADATA" : "MODE_UNSPECIFIED"
   node_workload_metadata_config         = lookup(local.cfg, "node_workload_metadata_config", local.default_node_workload_metadata_config)
+
+  master_authorized_networks_config_cidr_blocks_lookup = lookup(local.cfg, "master_authorized_networks_config_cidr_blocks", null)
+  master_authorized_networks_config_cidr_blocks        = local.master_authorized_networks_config_cidr_blocks_lookup == null ? null : split(",", local.master_authorized_networks_config_cidr_blocks_lookup)
 }

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -52,6 +52,8 @@ module "cluster" {
   cloud_nat_endpoint_independent_mapping = local.cloud_nat_endpoint_independent_mapping
   cloud_nat_ip_count                     = local.cloud_nat_ip_count
 
+  master_authorized_networks_config_cidr_blocks = local.master_authorized_networks_config_cidr_blocks
+
   cloud_nat_min_ports_per_vm = local.cloud_nat_min_ports_per_vm
 
   disable_workload_identity     = local.disable_workload_identity


### PR DESCRIPTION
Similar work than https://github.com/kbst/terraform-kubestack/pull/234/ but for GKE. Based on 

- https://cloud.google.com/kubernetes-engine/docs/concepts/private-cluster-concept
- https://cloud.google.com/kubernetes-engine/docs/how-to/authorized-networks
- using: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#master_authorized_networks_config

Based [on the docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#master_authorized_networks_config):

> master_authorized_networks_config - (Optional) The desired configuration options for master authorized networks. Omit the nested `cidr_blocks` attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists).

So I want to ensure that if `master_authorized_networks_config_cidr_blocks` is not set, then we don't end up with disallowing external access, as that would change the current behavior and would likely break lot of people's setup. Thus if the config is not specified, I'm setting `master_authorized_networks_config` to null.