### PR TITLE
AKS: enable automatic cluster upgrades

### DIFF
--- a/azurerm/_modules/aks/main.tf
+++ b/azurerm/_modules/aks/main.tf
@@ -3,12 +3,13 @@ data "azurerm_resource_group" "current" {
 }
 
 resource "azurerm_kubernetes_cluster" "current" {
-  name                = var.metadata_name
-  location            = data.azurerm_resource_group.current.location
-  resource_group_name = data.azurerm_resource_group.current.name
-  dns_prefix          = var.dns_prefix
-  sku_tier            = var.sku_tier
-  kubernetes_version  = var.kubernetes_version
+  name                      = var.metadata_name
+  location                  = data.azurerm_resource_group.current.location
+  resource_group_name       = data.azurerm_resource_group.current.name
+  dns_prefix                = var.dns_prefix
+  sku_tier                  = var.sku_tier
+  kubernetes_version        = var.kubernetes_version
+  automatic_channel_upgrade = var.automatic_channel_upgrade
 
   role_based_access_control {
     enabled = true

--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -168,6 +168,12 @@ variable "kubernetes_version" {
   description = "Version of Kubernetes to use when creating the cluster. If not specified, latest version will be used."
 }
 
+variable "automatic_channel_upgrade" {
+  type        = string
+  description = "The upgrade channel for this Kubernetes Cluster. Possible values are 'none', 'patch', 'rapid', 'node-image' and 'stable'. Defaults to 'none'."
+  default     = "none"
+}
+
 variable "enable_log_analytics" {
   type        = bool
   description = "whether to deploy the Azure Log analytics with the cluster"

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -54,5 +54,6 @@ locals {
 
   enable_log_analytics = lookup(local.cfg, "enable_log_analytics", true)
 
-  kubernetes_version = lookup(local.cfg, "kubernetes_version", null)
+  kubernetes_version        = lookup(local.cfg, "kubernetes_version", null)
+  automatic_channel_upgrade = lookup(local.cfg, "automatic_channel_upgrade", "none")
 }

--- a/azurerm/cluster/main.tf
+++ b/azurerm/cluster/main.tf
@@ -60,6 +60,7 @@ module "cluster" {
   disable_managed_identities = local.disable_managed_identities
   user_assigned_identity_id  = local.user_assigned_identity_id
 
-  kubernetes_version   = local.kubernetes_version
-  enable_log_analytics = local.enable_log_analytics
+  kubernetes_version        = local.kubernetes_version
+  automatic_channel_upgrade = local.automatic_channel_upgrade
+  enable_log_analytics      = local.enable_log_analytics
 }


### PR DESCRIPTION
Exposes [this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#automatic_channel_upgrade) option. Defaults to `"none"`, which is the silent default anyway