### PR TITLE
AKS: Remove in-cluster-module provider configuration

### DIFF
--- a/azurerm/cluster/providers.tf
+++ b/azurerm/cluster/providers.tf
@@ -1,3 +1,0 @@
-provider "azurerm" {
-  features {}
-}

--- a/quickstart/src/configurations/aks/aks_zero_providers.tf
+++ b/quickstart/src/configurations/aks/aks_zero_providers.tf
@@ -1,3 +1,7 @@
+provider "azurerm" {
+  features {}
+}
+
 provider "kustomization" {
   alias          = "aks_zero"
   kubeconfig_raw = module.aks_zero.kubeconfig

--- a/quickstart/src/configurations/multi-cloud/aks_zero_providers.tf
+++ b/quickstart/src/configurations/multi-cloud/aks_zero_providers.tf
@@ -1,3 +1,7 @@
+provider "azurerm" {
+  features {}
+}
+
 provider "kustomization" {
   alias          = "aks_zero"
   kubeconfig_raw = module.aks_zero.kubeconfig

--- a/tests/aks_zero_providers.tf
+++ b/tests/aks_zero_providers.tf
@@ -1,3 +1,7 @@
+provider "azurerm" {
+  features {}
+}
+
 provider "kustomization" {
   alias          = "aks_zero"
   kubeconfig_raw = module.aks_zero.kubeconfig


### PR DESCRIPTION
In module provider configurations are discouraged. The AKS cluster
module still had a left-over provider configuration to set
`features {}` for the azurerm provider.

This commit moves this out of the cluster module into the root
module for both the generated starters and tests/.