### PR TITLE
AKS: Fix invalid automatic_channel_upgrade value none

### DIFF
--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -170,8 +170,7 @@ variable "kubernetes_version" {
 
 variable "automatic_channel_upgrade" {
   type        = string
-  description = "The upgrade channel for this Kubernetes Cluster. Possible values are 'none', 'patch', 'rapid', 'node-image' and 'stable'. Defaults to 'none'."
-  default     = "none"
+  description = "The upgrade channel for this Kubernetes Cluster. Possible values are 'patch', 'rapid', 'node-image' and 'stable'."
 }
 
 variable "enable_log_analytics" {

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -55,5 +55,5 @@ locals {
   enable_log_analytics = lookup(local.cfg, "enable_log_analytics", true)
 
   kubernetes_version        = lookup(local.cfg, "kubernetes_version", null)
-  automatic_channel_upgrade = lookup(local.cfg, "automatic_channel_upgrade", "none")
+  automatic_channel_upgrade = lookup(local.cfg, "automatic_channel_upgrade", null)
 }


### PR DESCRIPTION
@to266 the tests fail with `Error: expected automatic_channel_upgrade to be one of [patch rapid stable node-image], got none`. I tried to fix this by making the default null. This way Kubestack/Terraform doesn't handle the attribute and will leave it to AKS to default to something. Your variable can still be used to select a specific channel.

Do you think that's the right approach or would you suggest to make e.g. `stable` the default channel?

![Screenshot 2021-11-17 at 16-54-35 Merge pull request #241 from to266 azure-cluster-upgrades · kbst terraform-kubestack 5b6f](https://user-images.githubusercontent.com/253456/142234990-2f1eda26-aba1-4216-a938-8d037454ef53.png)

