### PR TITLE
EKS: Remove depends_on from eks_zero_dns_zone

### DIFF
--- a/quickstart/src/configurations/eks/eks_zero_ingress.tf
+++ b/quickstart/src/configurations/eks/eks_zero_ingress.tf
@@ -26,6 +26,4 @@ module "eks_zero_dns_zone" {
   ingress_service_namespace = "ingress-nginx"
 
   metadata_fqdn = module.eks_zero.current_metadata["fqdn"]
-
-  depends_on = [module.eks_zero, module.eks_zero_nginx]
 }

--- a/quickstart/src/configurations/multi-cloud/eks_zero_ingress.tf
+++ b/quickstart/src/configurations/multi-cloud/eks_zero_ingress.tf
@@ -26,6 +26,4 @@ module "eks_zero_dns_zone" {
   ingress_service_namespace = "ingress-nginx"
 
   metadata_fqdn = module.eks_zero.current_metadata["fqdn"]
-
-  depends_on = [module.eks_zero, module.eks_zero_nginx]
 }

--- a/tests/eks_zero_ingress.tf
+++ b/tests/eks_zero_ingress.tf
@@ -31,6 +31,4 @@ module "eks_zero_dns_zone" {
   ingress_service_namespace = "ingress-nginx"
 
   metadata_fqdn = module.eks_zero.current_metadata["fqdn"]
-
-  depends_on = [module.eks_zero, module.eks_zero_nginx]
 }


### PR DESCRIPTION
The depends_on propagates to the data sources in the module
and causes the Route53 zone data source to only be read on
apply. This means the zone_id referenced in the Route53 host
resources will be in known-after-apply, which causes the
hosts to be recreated unnecessarily. Since this would cause
small time windows where uncached DNS queries would fail,
not having the explicit depends_on is the better compromise.
Even if it adds another reason why --target apply is required
during bootstrap or recreation.