### PR TITLE
Add azure aks default node pool availability_zones

### DIFF
--- a/azurerm/_modules/aks/main.tf
+++ b/azurerm/_modules/aks/main.tf
@@ -35,6 +35,8 @@ resource "azurerm_kubernetes_cluster" "current" {
     max_pods       = var.max_pods
 
     only_critical_addons_enabled = var.default_node_pool_only_critical_addons
+
+    availability_zones = var.availability_zones
   }
 
   network_profile {

--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -178,3 +178,9 @@ variable "enable_log_analytics" {
   description = "whether to deploy the Azure Log analytics with the cluster"
   default     = true
 }
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "The list of availability zones to create the node pool in"
+  default     = []
+}

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -57,6 +57,6 @@ locals {
   kubernetes_version        = lookup(local.cfg, "kubernetes_version", null)
   automatic_channel_upgrade = lookup(local.cfg, "automatic_channel_upgrade", null)
 
-  availability_zones_list = local.cfg["availability_zones"] != null ? local.cfg["availability_zones"] : []
-  availability_zones      = length(local.availability_zones_list) == 0 ? null : local.availability_zones_list
+  availability_zones_lookup = lookup(local.cfg, "availability_zones", "")
+  availability_zones        = local.availability_zones_lookup != "" ? split(",", local.availability_zones_lookup_lookup) : []
 }

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -56,4 +56,7 @@ locals {
 
   kubernetes_version        = lookup(local.cfg, "kubernetes_version", null)
   automatic_channel_upgrade = lookup(local.cfg, "automatic_channel_upgrade", null)
+
+  availability_zones_list = local.cfg["availability_zones"] != null ? local.cfg["availability_zones"] : []
+  availability_zones      = length(local.availability_zones_list) == 0 ? null : local.availability_zones_list
 }

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -58,5 +58,5 @@ locals {
   automatic_channel_upgrade = lookup(local.cfg, "automatic_channel_upgrade", null)
 
   availability_zones_lookup = lookup(local.cfg, "availability_zones", "")
-  availability_zones        = local.availability_zones_lookup != "" ? split(",", local.availability_zones_lookup_lookup) : []
+  availability_zones        = local.availability_zones_lookup != "" ? split(",", local.availability_zones_lookup) : []
 }

--- a/azurerm/cluster/main.tf
+++ b/azurerm/cluster/main.tf
@@ -63,4 +63,6 @@ module "cluster" {
   kubernetes_version        = local.kubernetes_version
   automatic_channel_upgrade = local.automatic_channel_upgrade
   enable_log_analytics      = local.enable_log_analytics
+
+  availability_zones = local.availability_zones
 }


### PR DESCRIPTION
https://github.com/kbst/terraform-kubestack/issues/252

Adds the option to set availability_zones. Defaults to None which is what the module did previously.