### PR TITLE
sign the images and promote signed images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,9 @@ jobs:
       matrix:
         starter: ["multi-cloud", "aks", "eks", "gke" ,"kind"]
 
+    permissions:
+      id-token: write # needed for keyless signing
+
     steps:
     - name: 'Checkout'
       uses: actions/checkout@v1
@@ -55,6 +58,9 @@ jobs:
       with:
         name: test-artifacts
         path: ./quickstart/_dist
+
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@116dc6872c0a067bcb78758f18955414cdbf918f #v1.4.1
 
     - name: 'Setup buildx'
       uses: docker/setup-buildx-action@v1
@@ -72,6 +78,12 @@ jobs:
         DOCKER_PUSH: true
         DOCKER_TARGET: ${{ matrix.starter }}
       run: make build
+
+    - name: 'Sign Images'
+      env:
+        COSIGN_EXPERIMENTAL: true
+      run: |
+        cosign sign --force -a GIT_HASH=${{ github.sha }} -a GIT_REF=${{ github.ref }} kubestack/framework-dev:test-${{ github.sha }}-${{ matrix.starter }}
 
   test:
     runs-on: ubuntu-latest
@@ -183,6 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
 
+
     strategy:
       matrix:
         starter: ["multi-cloud", "aks", "eks", "gke" ,"kind"]
@@ -194,6 +207,9 @@ jobs:
         name: test-artifacts
         path: ./quickstart/_dist
 
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@116dc6872c0a067bcb78758f18955414cdbf918f #v1.4.1
+
     - name: 'Docker login'
       uses: docker/login-action@v1
       with:
@@ -204,12 +220,16 @@ jobs:
       # pull the image built for testing
       # retag it as the image specified in the artifact
       # push the new image with the new tag
+      #
+      # cosign copy copies the images and the signature from one place to another
+      # then we dont need to sign again the same image
+      env:
+        COSIGN_EXPERIMENTAL: true
       run: |
         SOURCE_IMAGE=kubestack/framework-dev:test-${{ github.sha }}-${{ matrix.starter }}
         docker pull $SOURCE_IMAGE
         TARGET_IMAGE=$(cat quickstart/_dist/kubestack-starter-${{ matrix.starter }}/Dockerfile | sed 's/FROM //')
-        docker tag $SOURCE_IMAGE $TARGET_IMAGE
-        docker push $TARGET_IMAGE
+        cosign copy $SOURCE_IMAGE $TARGET_IMAGE
 
   publish-starter:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ build:
 		--progress plain \
 		--target ${DOCKER_TARGET} \
 		-t kubestack/framework-dev:test-$(GIT_SHA)-${DOCKER_TARGET} \
-		. 
+		.
 
 validate: .init
 	docker exec \

--- a/oci/Dockerfile
+++ b/oci/Dockerfile
@@ -113,7 +113,7 @@ FROM builder as kind-builder
 # https://docs.docker.com/engine/release-notes/
 ARG DOCKER_CLI_VERSION=20.10.10
 
-RUN mkdir -p /opt/bin   
+RUN mkdir -p /opt/bin
 
 # kind requires docker client
 RUN echo "DOCKER_CLI_VERSION: ${DOCKER_CLI_VERSION}" \


### PR DESCRIPTION
This PR adds a feature to sign the images that are generated using cosign (https://github.com/sigstore/cosign) and a keyless approach where it generates an ephemeral auth token to use during the signing process

the approach here is that we sign the staging image and when we promote that we carry over the image + the signature to avoid signing it again.

after this, I will work to sign the artifacts as well

