### PR TITLE
AWS: Enable setting of VPC DNS hostnames/support

### DIFF
--- a/aws/_modules/eks/variables.tf
+++ b/aws/_modules/eks/variables.tf
@@ -41,7 +41,7 @@ variable "vpc_dns_hostnames" {
 }
 
 variable "vpc_dns_support" {
-  description = "Enabled DNS support in the VPC."
+  description = "Enable DNS support in the VPC."
   type        = bool
   default     = false
 }

--- a/aws/_modules/eks/variables.tf
+++ b/aws/_modules/eks/variables.tf
@@ -34,6 +34,18 @@ variable "vpc_control_subnet_newbits" {
   type        = string
 }
 
+variable "vpc_dns_hostnames" {
+  description = "Enable DNS hostnames in the VPC."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_dns_support" {
+  description = "Enabled DNS support in the VPC."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_node_subnet_newbits" {
   description = "CIDR newbits to use for the node pool subnets."
   type        = string

--- a/aws/_modules/eks/vpc.tf
+++ b/aws/_modules/eks/vpc.tf
@@ -1,6 +1,9 @@
 resource "aws_vpc" "current" {
   cidr_block = var.vpc_cidr
 
+  enable_dns_hostnames = var.vpc_dns_hostnames
+  enable_dns_support   = var.vpc_dns_support
+
   tags = local.eks_metadata_tags
 }
 

--- a/aws/cluster/configuration.tf
+++ b/aws/cluster/configuration.tf
@@ -19,6 +19,8 @@ locals {
   cluster_vpc_cidr                      = lookup(local.cfg, "cluster_vpc_cidr", "10.0.0.0/16")
   cluster_vpc_subnet_newbits            = lookup(local.cfg, "cluster_vpc_subnet_newbits", "8") # kept for backward compatibility
   cluster_vpc_control_subnet_newbits    = lookup(local.cfg, "cluster_vpc_control_subnet_newbits", local.cluster_vpc_subnet_newbits)
+  cluster_vpc_dns_hostnames             = lookup(local.cfg, "cluster_vpc_dns_hostnames", false)
+  cluster_vpc_dns_support               = lookup(local.cfg, "cluster_vpc_dns_support", false)
   cluster_vpc_node_subnet_newbits       = lookup(local.cfg, "cluster_vpc_node_subnet_newbits", "4")
   cluster_vpc_node_subnet_number_offset = lookup(local.cfg, "cluster_vpc_node_subnet_number_offset", "1")
   cluster_vpc_legacy_node_subnets       = lookup(local.cfg, "cluster_vpc_legacy_node_subnets", false)

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -22,6 +22,8 @@ module "cluster" {
 
   vpc_cidr                      = local.cluster_vpc_cidr
   vpc_control_subnet_newbits    = local.cluster_vpc_control_subnet_newbits
+  vpc_dns_hostnames             = local.cluster_vpc_dns_hostnames
+  vpc_dns_support               = local.cluster_vpc_dns_support
   vpc_node_subnet_newbits       = local.cluster_vpc_node_subnet_newbits
   vpc_node_subnet_number_offset = local.cluster_vpc_node_subnet_number_offset
   vpc_legacy_node_subnets       = local.cluster_vpc_legacy_node_subnets


### PR DESCRIPTION
Allow passing DNS hostnames/support boolean from AWS cluster module.

Fixes #214 