### PR TITLE
Azure allow use of existing vnet

### DIFF
--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -44,9 +44,15 @@ variable "subnet_service_endpoints" {
   description = "List of service endpoints to expose on the subnet."
 }
 
-variable "existing_vnet_name" {
+variable "existing_vnet" {
   type        = string
   description = "Name of existing vnet to use."
+  default     = ""
+}
+
+variable "existing_vnet_resource_group" {
+  type        = string
+  description = "Name of existing resource group for existing vnet."
   default     = ""
 }
 

--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -44,6 +44,12 @@ variable "subnet_service_endpoints" {
   description = "List of service endpoints to expose on the subnet."
 }
 
+variable " existing_vnet_name" {
+  type        = string
+  description = "Name of existing vnet to use."
+  default     = null
+}
+
 variable "network_plugin" {
   type        = string
   description = "Network plugin to use. Set to 'azure' for CNI; 'kubenet' for Basic"

--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -44,7 +44,7 @@ variable "subnet_service_endpoints" {
   description = "List of service endpoints to expose on the subnet."
 }
 
-variable " existing_vnet_name" {
+variable "existing_vnet_name" {
   type        = string
   description = "Name of existing vnet to use."
   default     = null

--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -47,7 +47,7 @@ variable "subnet_service_endpoints" {
 variable "existing_vnet_name" {
   type        = string
   description = "Name of existing vnet to use."
-  default     = null
+  default     = ""
 }
 
 variable "network_plugin" {

--- a/azurerm/_modules/aks/vnet.tf
+++ b/azurerm/_modules/aks/vnet.tf
@@ -1,6 +1,6 @@
 
 resource "azurerm_virtual_network" "current" {
-  count = var.network_plugin == "azure" ? 1 : 0
+  count = !var.existing_vnet_name && var.network_plugin == "azure" ? 1 : 0
 
   name                = var.legacy_vnet_name ? "vnet-aks-${terraform.workspace}-cluster" : var.metadata_name
   address_space       = var.vnet_address_space
@@ -14,7 +14,7 @@ resource "azurerm_subnet" "current" {
   name                 = var.legacy_vnet_name ? "aks-node-subnet" : "${var.metadata_name}-${var.default_node_pool_name}-node-pool"
   address_prefixes     = var.subnet_address_prefixes
   resource_group_name  = data.azurerm_resource_group.current.name
-  virtual_network_name = azurerm_virtual_network.current[0].name
+  virtual_network_name = var.existing_vnet_name ? var.existing_vnet_name : azurerm_virtual_network.current[0].name
 
   service_endpoints = length(var.subnet_service_endpoints) > 0 ? var.subnet_service_endpoints : null
 }

--- a/azurerm/_modules/aks/vnet.tf
+++ b/azurerm/_modules/aks/vnet.tf
@@ -1,6 +1,6 @@
 
 resource "azurerm_virtual_network" "current" {
-  count = !var.existing_vnet_name && var.network_plugin == "azure" ? 1 : 0
+  count = var.existing_vnet_name == "" && var.network_plugin == "azure" ? 1 : 0
 
   name                = var.legacy_vnet_name ? "vnet-aks-${terraform.workspace}-cluster" : var.metadata_name
   address_space       = var.vnet_address_space
@@ -14,7 +14,7 @@ resource "azurerm_subnet" "current" {
   name                 = var.legacy_vnet_name ? "aks-node-subnet" : "${var.metadata_name}-${var.default_node_pool_name}-node-pool"
   address_prefixes     = var.subnet_address_prefixes
   resource_group_name  = data.azurerm_resource_group.current.name
-  virtual_network_name = var.existing_vnet_name ? var.existing_vnet_name : azurerm_virtual_network.current[0].name
+  virtual_network_name = var.existing_vnet_name != "" ? var.existing_vnet_name : azurerm_virtual_network.current[0].name
 
   service_endpoints = length(var.subnet_service_endpoints) > 0 ? var.subnet_service_endpoints : null
 }

--- a/azurerm/_modules/aks/vnet.tf
+++ b/azurerm/_modules/aks/vnet.tf
@@ -1,6 +1,6 @@
 
 resource "azurerm_virtual_network" "current" {
-  count = var.existing_vnet_name == "" && var.network_plugin == "azure" ? 1 : 0
+  count = var.existing_vnet == "" && var.network_plugin == "azure" ? 1 : 0
 
   name                = var.legacy_vnet_name ? "vnet-aks-${terraform.workspace}-cluster" : var.metadata_name
   address_space       = var.vnet_address_space
@@ -13,8 +13,8 @@ resource "azurerm_subnet" "current" {
 
   name                 = var.legacy_vnet_name ? "aks-node-subnet" : "${var.metadata_name}-${var.default_node_pool_name}-node-pool"
   address_prefixes     = var.subnet_address_prefixes
-  resource_group_name  = data.azurerm_resource_group.current.name
-  virtual_network_name = var.existing_vnet_name != "" ? var.existing_vnet_name : azurerm_virtual_network.current[0].name
+  resource_group_name  = var.existing_vnet_resource_group != "" ? var.existing_vnet_resource_group : data.azurerm_resource_group.current.name
+  virtual_network_name = var.existing_vnet != "" ? var.existing_vnet : azurerm_virtual_network.current[0].name
 
   service_endpoints = length(var.subnet_service_endpoints) > 0 ? var.subnet_service_endpoints : null
 }

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -26,6 +26,8 @@ locals {
   subnet_service_endpoints_lookup = lookup(local.cfg, "subnet_service_endpoints", "")
   subnet_service_endpoints        = local.subnet_service_endpoints_lookup != "" ? split(",", local.subnet_service_endpoints_lookup) : []
 
+  existing_vnet_name = lookup(local.cfg, "existing_vnet_name", null)
+
   network_plugin = lookup(local.cfg, "network_plugin", "kubenet")
   network_policy = lookup(local.cfg, "network_policy", "calico")
   service_cidr   = lookup(local.cfg, "service_cidr", "10.0.0.0/16")

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -26,7 +26,7 @@ locals {
   subnet_service_endpoints_lookup = lookup(local.cfg, "subnet_service_endpoints", "")
   subnet_service_endpoints        = local.subnet_service_endpoints_lookup != "" ? split(",", local.subnet_service_endpoints_lookup) : []
 
-  existing_vnet_name = lookup(local.cfg, "existing_vnet_name", null)
+  existing_vnet_name = lookup(local.cfg, "existing_vnet_name", "")
 
   network_plugin = lookup(local.cfg, "network_plugin", "kubenet")
   network_policy = lookup(local.cfg, "network_policy", "calico")

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -26,7 +26,8 @@ locals {
   subnet_service_endpoints_lookup = lookup(local.cfg, "subnet_service_endpoints", "")
   subnet_service_endpoints        = local.subnet_service_endpoints_lookup != "" ? split(",", local.subnet_service_endpoints_lookup) : []
 
-  existing_vnet_name = lookup(local.cfg, "existing_vnet_name", "")
+  existing_vnet                = lookup(local.cfg, "existing_vnet", "")
+  existing_vnet_resource_group = lookup(local.cfg, "existing_vnet_resource_group", "")
 
   network_plugin = lookup(local.cfg, "network_plugin", "kubenet")
   network_policy = lookup(local.cfg, "network_policy", "calico")

--- a/azurerm/cluster/main.tf
+++ b/azurerm/cluster/main.tf
@@ -33,6 +33,7 @@ module "cluster" {
   vnet_address_space       = local.vnet_address_space
   subnet_address_prefixes  = local.subnet_address_prefixes
   subnet_service_endpoints = local.subnet_service_endpoints
+  existing_vnet_name       = local.existing_vnet_name
 
   network_plugin = local.network_plugin
   network_policy = local.network_policy

--- a/azurerm/cluster/main.tf
+++ b/azurerm/cluster/main.tf
@@ -29,11 +29,12 @@ module "cluster" {
 
   sku_tier = local.sku_tier
 
-  legacy_vnet_name         = local.legacy_vnet_name
-  vnet_address_space       = local.vnet_address_space
-  subnet_address_prefixes  = local.subnet_address_prefixes
-  subnet_service_endpoints = local.subnet_service_endpoints
-  existing_vnet_name       = local.existing_vnet_name
+  legacy_vnet_name             = local.legacy_vnet_name
+  vnet_address_space           = local.vnet_address_space
+  subnet_address_prefixes      = local.subnet_address_prefixes
+  subnet_service_endpoints     = local.subnet_service_endpoints
+  existing_vnet                = local.existing_vnet
+  existing_vnet_resource_group = local.existing_vnet_resource_group
 
   network_plugin = local.network_plugin
   network_policy = local.network_policy


### PR DESCRIPTION
We had a use case where the aks cluster needed to be attached to an existing vnet, instead of creating a new vnet.

This pull request allows setting the subnet as part of a existing vnet. Defaults to creating a new vnet if the variables aren't set, matching previously behavior.