### PR TITLE
Revert configurable VPC DNS settings to previous default

### DIFF
--- a/aws/_modules/eks/variables.tf
+++ b/aws/_modules/eks/variables.tf
@@ -37,13 +37,11 @@ variable "vpc_control_subnet_newbits" {
 variable "vpc_dns_hostnames" {
   description = "Enable DNS hostnames in the VPC."
   type        = bool
-  default     = false
 }
 
 variable "vpc_dns_support" {
   description = "Enable DNS support in the VPC."
   type        = bool
-  default     = false
 }
 
 variable "vpc_node_subnet_newbits" {

--- a/aws/cluster/configuration.tf
+++ b/aws/cluster/configuration.tf
@@ -20,7 +20,7 @@ locals {
   cluster_vpc_subnet_newbits            = lookup(local.cfg, "cluster_vpc_subnet_newbits", "8") # kept for backward compatibility
   cluster_vpc_control_subnet_newbits    = lookup(local.cfg, "cluster_vpc_control_subnet_newbits", local.cluster_vpc_subnet_newbits)
   cluster_vpc_dns_hostnames             = lookup(local.cfg, "cluster_vpc_dns_hostnames", false)
-  cluster_vpc_dns_support               = lookup(local.cfg, "cluster_vpc_dns_support", false)
+  cluster_vpc_dns_support               = lookup(local.cfg, "cluster_vpc_dns_support", true)
   cluster_vpc_node_subnet_newbits       = lookup(local.cfg, "cluster_vpc_node_subnet_newbits", "4")
   cluster_vpc_node_subnet_number_offset = lookup(local.cfg, "cluster_vpc_node_subnet_number_offset", "1")
   cluster_vpc_legacy_node_subnets       = lookup(local.cfg, "cluster_vpc_legacy_node_subnets", false)
@@ -32,7 +32,7 @@ locals {
 
   cluster_additional_node_tags_lookup = lookup(local.cfg, "cluster_additional_node_tags", "")
   cluster_additional_node_tags_tuples = [for t in split(",", local.cluster_additional_node_tags_lookup) : split("=", t)]
-  cluster_additional_node_tags        = {for t in local.cluster_additional_node_tags_tuples : t[0] => t[1] if length(t) == 2}
+  cluster_additional_node_tags        = { for t in local.cluster_additional_node_tags_tuples : t[0] => t[1] if length(t) == 2 }
 
   cluster_desired_capacity = local.cfg["cluster_desired_capacity"]
 


### PR DESCRIPTION
Before making this configurable the defaults were DNS hostnames
disabled and DNS support enabled. With the defaults set in the
previous PR the nodes are not able to join the cluster. DNS
support needs to be enabled.

I also removed the defaults from the variables. I believe it's
better to set the defaults only in one place.