### PR TITLE
EKS Logging feature optional or disable it completely

### DIFF
--- a/aws/cluster/configuration.tf
+++ b/aws/cluster/configuration.tf
@@ -52,7 +52,7 @@ locals {
   disable_default_ingress = lookup(local.cfg, "disable_default_ingress", false)
 
   enabled_cluster_log_types_lookup = lookup(local.cfg, "enabled_cluster_log_types", "api,audit,authenticator,controllerManager,scheduler")
-  enabled_cluster_log_types        = split(",", local.enabled_cluster_log_types_lookup)
+  enabled_cluster_log_types        = compact(split(",", local.enabled_cluster_log_types_lookup))
 
   disable_openid_connect_provider = lookup(local.cfg, "disable_openid_connect_provider", false)
 


### PR DESCRIPTION
Currently `enabled_cluster_log_types`  variable by default enables logging for all EKS components in Cloudwatch. With these changes we can:

Disable EKS logging completely: 
```
enabled_cluster_log_types = ""
```
Selectively enable logging for EKS Controlplane components:
```
enabled_cluster_log_types  = "<use command separated from available options>"
e.g. enabled_cluster_log_types  = "audit" ## This would enable only audit logging for EKS and send logs to Cloudwatch
```
![image](https://user-images.githubusercontent.com/97720300/155879511-e6e21804-da93-4db5-bdd5-ede8d522382a.png)
