### PR TITLE
EKS: Enable specifying of KMS arn for cluster encryption

### DIFF
--- a/aws/_modules/eks/master.tf
+++ b/aws/_modules/eks/master.tf
@@ -10,6 +10,17 @@ resource "aws_eks_cluster" "current" {
     public_access_cidrs     = var.cluster_public_access_cidrs
   }
 
+  dynamic "encryption_config" {
+    for_each = var.cluster_encryption_key_arn != null ? toset([1]) : toset([])
+    content {
+      resources = ["secrets"]
+
+      provider {
+        key_arn = var.cluster_encryption_key_arn
+      }
+    }
+  }
+
   depends_on = [
     aws_iam_role_policy_attachment.master_cluster_policy,
     aws_iam_role_policy_attachment.master_service_policy,

--- a/aws/_modules/eks/variables.tf
+++ b/aws/_modules/eks/variables.tf
@@ -159,3 +159,9 @@ variable "cluster_public_access_cidrs" {
   default     = null
   description = "List of CIDR blocks which can access the Amazon EKS public API server endpoint. EKS defaults this to a list with 0.0.0.0/0."
 }
+
+variable "cluster_encryption_key_arn" {
+  type        = string
+  default     = null
+  description = "Arn of an AWS KMS symmetric key to be used for encryption of kubernetes resources."
+}

--- a/aws/cluster/configuration.tf
+++ b/aws/cluster/configuration.tf
@@ -60,4 +60,6 @@ locals {
   cluster_endpoint_public_access     = lookup(local.cfg, "cluster_endpoint_public_access", true)
   cluster_public_access_cidrs_lookup = lookup(local.cfg, "cluster_public_access_cidrs", null)
   cluster_public_access_cidrs        = local.cluster_public_access_cidrs_lookup == null ? null : split(",", local.cluster_public_access_cidrs_lookup)
+
+  cluster_encryption_key_arn = lookup(local.cfg, "cluster_encryption_key_arn", null)
 }

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -54,6 +54,8 @@ module "cluster" {
   cluster_endpoint_public_access  = local.cluster_endpoint_public_access
   cluster_public_access_cidrs     = local.cluster_public_access_cidrs
 
+  cluster_encryption_key_arn = local.cluster_encryption_key_arn
+
   # cluster module configuration is still map(string)
   # once module_variable_optional_attrs isn't experimental anymore
   # we can migrate cluster module configuration to map(object(...))


### PR DESCRIPTION
Enable cluster encryption as per [docs](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html#enable-kms)