### PR TITLE
GKE: Enable specifying of Cloud KSM key name for cluster database encryption

### DIFF
--- a/google/_modules/gke/cluster.tf
+++ b/google/_modules/gke/cluster.tf
@@ -25,6 +25,14 @@ resource "google_container_cluster" "current" {
     }
   }
 
+  dynamic "database_encryption" {
+    for_each = var.cluster_database_encryption_key_name != null ? toset([1]) : toset([])
+    content {
+      state = "ENCRYPTED"
+      key_name = var.cluster_database_encryption_key_name
+    }
+  }
+
   #
   #
   # Addon config

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -168,3 +168,8 @@ variable "enable_tpu" {
   description = "Whether to enable GKE cloud TPU support."
   type        = bool
 }
+
+variable "cluster_database_encryption_key_name" {
+  type        = string
+  description = "Cloud KMS key name for enabling cluster database encryption."
+}

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -60,6 +60,8 @@ locals {
   cluster_ipv4_cidr_block = lookup(local.cfg, "cluster_ipv4_cidr_block", null)
   services_ipv4_cidr_block = lookup(local.cfg, "services_ipv4_cidr_block", null)
 
+  cluster_database_encryption_key_name = lookup(local.cfg, "cluster_database_encryption_key_name", false)
+
   # by default include cloud_nat when private nodes are enabled
   enable_cloud_nat                       = lookup(local.cfg, "enable_cloud_nat", local.enable_private_nodes)
   cloud_nat_endpoint_independent_mapping = lookup(local.cfg, "cloud_nat_enable_endpoint_independent_mapping", null)

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -63,5 +63,7 @@ module "cluster" {
   disable_workload_identity     = local.disable_workload_identity
   node_workload_metadata_config = local.node_workload_metadata_config
 
+  cluster_database_encryption_key_name = local.cluster_database_encryption_key_name
+
   enable_tpu = local.enable_tpu
 }


### PR DESCRIPTION
Enable cluster database encryption as per [doc](https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets)