### PR TITLE
GKE: Enable specifying of intranode visibility for cluster

### DIFF
--- a/google/_modules/gke/cluster.tf
+++ b/google/_modules/gke/cluster.tf
@@ -82,5 +82,6 @@ resource "google_container_cluster" "current" {
     }
   }
 
-  enable_tpu = var.enable_tpu
+  enable_intranode_visibility = var.enable_intranode_visibility
+  enable_tpu                  = var.enable_tpu
 }

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -164,6 +164,11 @@ variable "master_authorized_networks_config_cidr_blocks" {
   type        = list(string)
 }
 
+variable "enable_intranode_visibility" {
+  description = "Whether to enable GKE intranode visibility."
+  type        = bool
+}
+
 variable "enable_tpu" {
   description = "Whether to enable GKE cloud TPU support."
   type        = bool

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -73,5 +73,6 @@ locals {
   master_authorized_networks_config_cidr_blocks_lookup = lookup(local.cfg, "master_authorized_networks_config_cidr_blocks", null)
   master_authorized_networks_config_cidr_blocks        = local.master_authorized_networks_config_cidr_blocks_lookup == null ? null : split(",", local.master_authorized_networks_config_cidr_blocks_lookup)
 
-  enable_tpu = lookup(local.cfg, "enable_tpu", false)
+  enable_intranode_visibility = lookup(local.cfg, "enable_intranode_visibility", false )
+  enable_tpu                  = lookup(local.cfg, "enable_tpu", false)
 }

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -63,5 +63,6 @@ module "cluster" {
   disable_workload_identity     = local.disable_workload_identity
   node_workload_metadata_config = local.node_workload_metadata_config
 
-  enable_tpu = local.enable_tpu
+  enable_intranode_visibility = local.enable_intranode_visibility
+  enable_tpu                  = local.enable_tpu
 }


### PR DESCRIPTION
Allow enabling of [intranode visibility](https://cloud.google.com/kubernetes-engine/docs/how-to/intranode-visibility) for cluster