### PR TITLE
GKE Cloud Router: support BGP router advertise config

### DIFF
--- a/google/_modules/gke/network.tf
+++ b/google/_modules/gke/network.tf
@@ -49,7 +49,11 @@ resource "google_compute_router" "current" {
         description = range.value
       }
     }
-    asn = var.router_asn
+
+    # expected "bgp.0.asn" to be a RFC6996-compliant Local ASN:
+    # must be either in the private ASN ranges: [64512..65534], [4200000000..4294967294];
+    # or be the value of [16550]
+    asn = var.router_asn != null ? var.router_asn : 16550
   }
 }
 

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -178,3 +178,19 @@ variable "cluster_database_encryption_key_name" {
   type        = string
   description = "Cloud KMS key name for enabling cluster database encryption."
 }
+
+variable "router_advertise_config" {
+  description = "Router custom advertisement configuration, ip_ranges is a map of address ranges and descriptions."
+  type = object({
+    groups    = list(string)
+    ip_ranges = map(string)
+    mode      = string
+  })
+  default = null
+}
+
+variable "router_asn" {
+  description = "Router ASN used for auto-created router."
+  type        = number
+  default     = null
+}

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -186,11 +186,9 @@ variable "router_advertise_config" {
     ip_ranges = map(string)
     mode      = string
   })
-  default = null
 }
 
 variable "router_asn" {
   description = "Router ASN used for auto-created router."
   type        = number
-  default     = null
 }

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -78,6 +78,10 @@ locals {
   enable_intranode_visibility = lookup(local.cfg, "enable_intranode_visibility", false)
   enable_tpu                  = lookup(local.cfg, "enable_tpu", false)
 
-  router_advertise_config = lookup(local.cfg, "router_advertise_config", null)
-  router_asn              = lookup(local.cfg, "router_asn", null)
+  router_advertise_config_groups_lookup    = lookup(local.cfg, "router_advertise_config_groups", "")
+  router_advertise_config_groups           = compact(split(",", local.router_advertise_config_groups_lookup))
+  router_advertise_config_ip_ranges_lookup = lookup(local.cfg, "router_advertise_config_ip_ranges", "")
+  router_advertise_config_ip_ranges        = compact(split(",", local.router_advertise_config_ip_ranges_lookup))
+  router_advertise_config_mode             = lookup(local.cfg, "router_advertise_config_mode", null)
+  router_asn                               = lookup(local.cfg, "router_asn", null)
 }

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -77,4 +77,7 @@ locals {
 
   enable_intranode_visibility = lookup(local.cfg, "enable_intranode_visibility", false)
   enable_tpu                  = lookup(local.cfg, "enable_tpu", false)
+
+  router_advertise_config = lookup(local.cfg, "router_advertise_config", null)
+  router_asn              = lookup(local.cfg, "router_asn", null)
 }

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -68,6 +68,10 @@ module "cluster" {
   enable_intranode_visibility = local.enable_intranode_visibility
   enable_tpu                  = local.enable_tpu
 
-  router_advertise_config = local.router_advertise_config
-  router_asn              = local.router_asn
+  router_advertise_config = {
+    groups    = local.router_advertise_config_groups
+    ip_ranges = { for ip in local.router_advertise_config_ip_ranges : ip => null }
+    mode      = local.router_advertise_config_mode
+  }
+  router_asn = local.router_asn
 }

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -67,4 +67,7 @@ module "cluster" {
 
   enable_intranode_visibility = local.enable_intranode_visibility
   enable_tpu                  = local.enable_tpu
+
+  router_advertise_config = local.router_advertise_config
+  router_asn              = local.router_asn
 }


### PR DESCRIPTION
Adds support for Cloud Router BGP advertisement configuration.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router#bgp