### PR TITLE
EKS: Fix deprecation warning for aws_subnet_ids

### DIFF
--- a/aws/cluster/node-pool/configuration.tf
+++ b/aws/cluster/node-pool/configuration.tf
@@ -21,8 +21,8 @@ locals {
   availability_zones_lookup = local.cfg["availability_zones"] == null ? "" : local.cfg["availability_zones"]
   availability_zones        = compact(split(",", local.availability_zones_lookup))
 
-  az_subnet_ids            = length(data.aws_subnet_ids.current) == 1 ? data.aws_subnet_ids.current[0].ids : []
-  default_subnet_ids       = length(data.aws_subnet_ids.current) == 1 ? local.az_subnet_ids : tolist(data.aws_eks_node_group.default.subnet_ids)
+  az_subnet_ids            = length(data.aws_subnets.current) == 1 ? data.aws_subnets.current[0].ids : []
+  default_subnet_ids       = length(data.aws_subnets.current) == 1 ? local.az_subnet_ids : tolist(data.aws_eks_node_group.default.subnet_ids)
   vpc_subnet_ids           = local.cfg["vpc_subnet_ids"] == null ? local.default_subnet_ids : split(",", local.cfg["vpc_subnet_ids"])
   vpc_secondary_cidr       = lookup(local.cfg, "vpc_secondary_cidr", null)
   vpc_subnet_newbits       = lookup(local.cfg, "vpc_subnet_newbits", null)

--- a/aws/cluster/node-pool/data_sources.tf
+++ b/aws/cluster/node-pool/data_sources.tf
@@ -13,10 +13,13 @@ data "aws_vpc" "current" {
   id = data.aws_eks_cluster.current.vpc_config[0].vpc_id
 }
 
-data "aws_subnet_ids" "current" {
+data "aws_subnets" "current" {
   count = length(local.availability_zones) > 0 ? 1 : 0
 
-  vpc_id = data.aws_vpc.current.id
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.current.id]
+  }
 
   # if the node pool is in one or more specific AZs
   # only link subnet_ids belonging to these AZs


### PR DESCRIPTION
## Summary

Fixes deprecation warning on `aws_subnet_ids`. Change to [aws_subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets)

<details>
<summary>Example</summary>

```terraform
Warning: Deprecated Resource

  with module.my_app.data.aws_subnet_ids.current,
  on .terraform/modules/eks_apne1_one_node_pool_machine_learning/aws/cluster/node-pool/data_sources.tf line 16, in data "aws_subnet_ids" "current":
  16: data "aws_subnet_ids" "current" {

The aws_subnet_ids data source has been deprecated and will be removed in a
future version. Use the aws_subnets data source instead.
```

</details>

