### PR TITLE
EKS nodegroups: support setting launch_template

### DIFF
--- a/aws/_modules/eks/node_pool/main.tf
+++ b/aws/_modules/eks/node_pool/main.tf
@@ -38,6 +38,12 @@ resource "aws_eks_node_group" "nodes" {
     }
   }
 
+  launch_template {
+    id      = var.launch_template_id
+    name    = var.launch_template_name
+    version = var.launch_template_version
+  }
+
   depends_on = [var.depends-on-aws-auth]
 
   # when autoscaler is enabled, desired_size needs to be ignored

--- a/aws/_modules/eks/node_pool/variables.tf
+++ b/aws/_modules/eks/node_pool/variables.tf
@@ -89,3 +89,21 @@ variable "kubernetes_version" {
   type        = string
   description = "Kubernetes version to use for node pool."
 }
+
+variable "launch_template_id" {
+  type        = string
+  default     = null
+  description = "Identifier of the EC2 Launch Template. Conflicts with launch_template_name."
+}
+
+variable "launch_template_name" {
+  type        = string
+  default     = null
+  description = "Name of the EC2 Launch Template. Conflicts with launch_template_id."
+}
+
+variable "launch_template_version" {
+  type        = string
+  default     = null
+  description = "EC2 Launch Template version number."
+}

--- a/aws/cluster/node-pool/configuration.tf
+++ b/aws/cluster/node-pool/configuration.tf
@@ -31,6 +31,10 @@ locals {
 
   taints = local.cfg["taints"] == null ? toset([]) : local.cfg["taints"]
 
+  launch_template_id      = lookup(local.cfg, "launch_template_id", null)
+  launch_template_name    = lookup(local.cfg, "launch_template_name", null)
+  launch_template_version = lookup(local.cfg, "launch_template_version", null)
+
   tags = local.cfg["tags"]
 
   labels = local.cfg["labels"]

--- a/aws/cluster/node-pool/main.tf
+++ b/aws/cluster/node-pool/main.tf
@@ -35,6 +35,10 @@ module "node_pool" {
 
   tags = local.tags
 
+  launch_template_id      = local.launch_template_id
+  launch_template_name    = local.launch_template_name
+  launch_template_version = local.launch_template_version
+
   labels = local.labels
 
   depends-on-aws-auth = null

--- a/aws/cluster/node-pool/variables.tf
+++ b/aws/cluster/node-pool/variables.tf
@@ -27,6 +27,10 @@ variable "configuration" {
       effect = string
     })))
 
+    launch_template_id      = optional(string)
+    launch_template_name    = optional(string)
+    launch_template_version = optional(string)
+
     tags = optional(map(string))
 
     labels = optional(map(string))


### PR DESCRIPTION
Adds passing three new parameters:
```
launch_template_id
launch_template_name
launch_template_version
```
to according object in`aws_eks_node_group`: `launch_template`.

Id and name are mutually exclusive, so only one of them should be set at a time.