### PR TITLE
GKE: add support for logging_config

### DIFF
--- a/google/_modules/gke/cluster.tf
+++ b/google/_modules/gke/cluster.tf
@@ -75,6 +75,13 @@ resource "google_container_cluster" "current" {
     }
   }
 
+  dynamic "logging_config" {
+    for_each = var.logging_config != null ? [""] : []
+    content {
+      enable_components = var.logging_config
+    }
+  }
+
   private_cluster_config {
     enable_private_nodes    = var.enable_private_nodes
     enable_private_endpoint = false

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -192,3 +192,8 @@ variable "router_asn" {
   description = "Router ASN used for auto-created router."
   type        = number
 }
+
+variable "logging_config" {
+  description = "Logging configuration."
+  type        = list(string)
+}

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -84,4 +84,7 @@ locals {
   router_advertise_config_ip_ranges        = compact(split(",", local.router_advertise_config_ip_ranges_lookup))
   router_advertise_config_mode             = lookup(local.cfg, "router_advertise_config_mode", null)
   router_asn                               = lookup(local.cfg, "router_asn", null)
+
+  logging_config_enabled_components_lookup = lookup(local.cfg, "logging_config_enabled_components", "")
+  logging_config_enabled_components        = compact(split(",", local.logging_config_enabled_components_lookup))
 }

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -74,4 +74,6 @@ module "cluster" {
     mode      = local.router_advertise_config_mode
   }
   router_asn = local.router_asn
+
+  logging_config = local.logging_config_enabled_components
 }


### PR DESCRIPTION
Adds support for setting `logging_config` configuration block.

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#logging_config