### PR TITLE
GKE: add support for monitoring_config

### DIFF
--- a/google/_modules/gke/cluster.tf
+++ b/google/_modules/gke/cluster.tf
@@ -75,6 +75,21 @@ resource "google_container_cluster" "current" {
     }
   }
 
+  dynamic "monitoring_config" {
+    for_each = var.monitoring_config != null ? [""] : []
+    content {
+      enable_components = var.monitoring_config
+      dynamic "managed_prometheus" {
+        for_each = (
+          try(var.monitoring_config_managed_prometheus, null) == true ? [""] : []
+        )
+        content {
+          enabled = true
+        }
+      }
+    }
+  }
+
   private_cluster_config {
     enable_private_nodes    = var.enable_private_nodes
     enable_private_endpoint = false

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -192,3 +192,14 @@ variable "router_asn" {
   description = "Router ASN used for auto-created router."
   type        = number
 }
+
+
+variable "monitoring_config" {
+  description = "Monitoring configuration."
+  type        = list(string)
+}
+
+variable "monitoring_config_managed_prometheus" {
+  description = "Monitoring configuration managed prometheus."
+  type        = bool
+}

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -84,4 +84,8 @@ locals {
   router_advertise_config_ip_ranges        = compact(split(",", local.router_advertise_config_ip_ranges_lookup))
   router_advertise_config_mode             = lookup(local.cfg, "router_advertise_config_mode", null)
   router_asn                               = lookup(local.cfg, "router_asn", null)
+
+  monitoring_config_enabled_components_lookup = lookup(local.cfg, "monitoring_config_enabled_components", "")
+  monitoring_config_enabled_components        = compact(split(",", local.monitoring_config_enabled_components_lookup))
+  monitoring_config_managed_prometheus        = lookup(local.cfg, "monitoring_config_managed_prometheus", null)
 }

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -74,4 +74,7 @@ module "cluster" {
     mode      = local.router_advertise_config_mode
   }
   router_asn = local.router_asn
+
+  monitoring_config                    = local.monitoring_config_enabled_components
+  monitoring_config_managed_prometheus = local.monitoring_config_managed_prometheus
 }


### PR DESCRIPTION
Adds support for setting `monitoring_config` configuration block.

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#monitoring_config