### PR TITLE
Allow passing additional labels/tags to AKS clusters

### DIFF
--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -63,7 +63,7 @@ locals {
   availability_zones_lookup = lookup(local.cfg, "availability_zones", "")
   availability_zones        = local.availability_zones_lookup != "" ? split(",", local.availability_zones_lookup) : []
 
-  cluster_additional_labels_lookup = lookup(local.cfg, "labels", "")
-  cluster_additional_labels_tuples = [for t in split(",", local.cluster_additional_labels_lookup) : split("=", t)]
-  cluster_additional_labels        = { for t in local.cluster_additional_labels_tuples : t[0] => t[1] if length(t) == 2 }
+  additional_metadata_labels_lookup = lookup(local.cfg, "additional_metadata_labels", "")
+  additional_metadata_labels_tuples = [for t in split(",", local.additional_metadata_labels_lookup) : split("=", t)]
+  additional_metadata_labels        = { for t in local.additional_metadata_labels_tuples : t[0] => t[1] if length(t) == 2 }
 }

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -62,4 +62,8 @@ locals {
 
   availability_zones_lookup = lookup(local.cfg, "availability_zones", "")
   availability_zones        = local.availability_zones_lookup != "" ? split(",", local.availability_zones_lookup) : []
+
+  cluster_additional_labels_lookup = lookup(local.cfg, "labels", "")
+  cluster_additional_labels_tuples = [for t in split(",", local.cluster_additional_labels_lookup) : split("=", t)]
+  cluster_additional_labels        = { for t in local.cluster_additional_labels_tuples : t[0] => t[1] if length(t) == 2 }
 }

--- a/azurerm/cluster/main.tf
+++ b/azurerm/cluster/main.tf
@@ -22,7 +22,7 @@ module "cluster" {
 
   metadata_name            = module.cluster_metadata.name
   metadata_fqdn            = module.cluster_metadata.fqdn
-  metadata_labels          = merge(module.cluster_metadata.labels, local.cluster_additional_labels)
+  metadata_labels          = merge(module.cluster_metadata.labels, local.additional_metadata_labels)
   metadata_label_namespace = module.cluster_metadata.label_namespace
 
   dns_prefix = local.dns_prefix

--- a/azurerm/cluster/main.tf
+++ b/azurerm/cluster/main.tf
@@ -22,7 +22,7 @@ module "cluster" {
 
   metadata_name            = module.cluster_metadata.name
   metadata_fqdn            = module.cluster_metadata.fqdn
-  metadata_labels          = module.cluster_metadata.labels
+  metadata_labels          = merge(module.cluster_metadata.labels, local.cluster_additional_labels)
   metadata_label_namespace = module.cluster_metadata.label_namespace
 
   dns_prefix = local.dns_prefix


### PR DESCRIPTION
(disclaimer: haven't yet tested if this does what I want, but seems pretty straightforward, so PR'ing immediately)

The intrinsic need is to allow customizing / adding additional labels/tags on AKS resources managed by kubestack. For example, adding various tags as required by [Vanta](https://help.vanta.com/hc/en-us/articles/9270488281492-Bulk-Tags) (`VantaOwner` and similar)