### PR TITLE
gke: add enable_gcs_fuse_csi_driver switch

### DIFF
--- a/google/_modules/gke/cluster.tf
+++ b/google/_modules/gke/cluster.tf
@@ -48,6 +48,10 @@ resource "google_container_cluster" "current" {
     network_policy_config {
       disabled = false
     }
+
+    gcs_fuse_csi_driver_config {
+      enabled = var.enable_gcs_fuse_csi_driver
+    }
   }
 
   network_policy {

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -202,3 +202,8 @@ variable "monitoring_config_enable_components" {
   description = "Monitoring config components to enable."
   type        = list(string)
 }
+
+variable "enable_gcs_fuse_csi_driver" {
+  description = "Whether to enable GCSFuse CSI driver addon."
+  type        = bool
+}

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -90,4 +90,6 @@ locals {
 
   monitoring_config_enable_components_lookup = lookup(local.cfg, "monitoring_config_enable_components", "SYSTEM_COMPONENTS")
   monitoring_config_enable_components        = compact(split(",", local.monitoring_config_enable_components_lookup))
+
+  enable_gcs_fuse_csi_driver = lookup(local.cfg, "enable_gcs_fuse_csi_driver", false)
 }

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -77,4 +77,6 @@ module "cluster" {
 
   logging_config_enable_components    = local.logging_config_enable_components
   monitoring_config_enable_components = local.monitoring_config_enable_components
+
+  enable_gcs_fuse_csi_driver = local.enable_gcs_fuse_csi_driver
 }


### PR DESCRIPTION
Adds support for [gcs_fuse_csi_driver_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#gcs_fuse_csi_driver_config)