### PR TITLE
Fix gcs fuse csi default false to null

### DIFF
--- a/google/_modules/gke/cluster.tf
+++ b/google/_modules/gke/cluster.tf
@@ -49,8 +49,12 @@ resource "google_container_cluster" "current" {
       disabled = false
     }
 
-    gcs_fuse_csi_driver_config {
-      enabled = var.enable_gcs_fuse_csi_driver
+    dynamic "gcs_fuse_csi_driver_config" {
+      for_each = var.enable_gcs_fuse_csi_driver != null ? [1] : []
+
+      content {
+        enabled = var.enable_gcs_fuse_csi_driver
+      }
     }
   }
 

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -92,5 +92,5 @@ locals {
   monitoring_config_enable_components_lookup = lookup(local.cfg, "monitoring_config_enable_components", "SYSTEM_COMPONENTS")
   monitoring_config_enable_components        = compact(split(",", local.monitoring_config_enable_components_lookup))
 
-  enable_gcs_fuse_csi_driver = lookup(local.cfg, "enable_gcs_fuse_csi_driver", false)
+  enable_gcs_fuse_csi_driver = lookup(local.cfg, "enable_gcs_fuse_csi_driver", null)
 }


### PR DESCRIPTION
False causes a rolling update of existing cluster
control planes, just because it explicitly sets
it to false.

Default null prevents that by allowing to make
the add-on block conditional.