### PR TITLE
EKS: Allow configuring Service CIDR

### DIFF
--- a/aws/_modules/eks/master.tf
+++ b/aws/_modules/eks/master.tf
@@ -10,6 +10,10 @@ resource "aws_eks_cluster" "current" {
     public_access_cidrs     = var.cluster_public_access_cidrs
   }
 
+  kubernetes_network_config {
+    service_ipv4_cidr = var.cluster_service_cidr
+  }
+
   dynamic "encryption_config" {
     for_each = var.cluster_encryption_key_arn != null ? toset([1]) : toset([])
     content {

--- a/aws/_modules/eks/variables.tf
+++ b/aws/_modules/eks/variables.tf
@@ -160,6 +160,12 @@ variable "cluster_public_access_cidrs" {
   description = "List of CIDR blocks which can access the Amazon EKS public API server endpoint. EKS defaults this to a list with 0.0.0.0/0."
 }
 
+variable "cluster_service_cidr" {
+  type        = string
+  default     = null
+  description = "Sets the Service CIDR for the EKS cluster. EKS defaults this to 172.20.0.0/0."
+}
+
 variable "cluster_encryption_key_arn" {
   type        = string
   default     = null

--- a/aws/cluster/configuration.tf
+++ b/aws/cluster/configuration.tf
@@ -82,6 +82,7 @@ locals {
   cluster_endpoint_public_access     = lookup(local.cfg, "cluster_endpoint_public_access", true)
   cluster_public_access_cidrs_lookup = lookup(local.cfg, "cluster_public_access_cidrs", null)
   cluster_public_access_cidrs        = local.cluster_public_access_cidrs_lookup == null ? null : split(",", local.cluster_public_access_cidrs_lookup)
+  cluster_service_cidr               = lookup(local.cfg, "cluster_service_cidr", "172.20.0.0/16")
 
   cluster_encryption_key_arn = lookup(local.cfg, "cluster_encryption_key_arn", null)
 }

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -55,6 +55,7 @@ module "cluster" {
   cluster_endpoint_private_access = local.cluster_endpoint_private_access
   cluster_endpoint_public_access  = local.cluster_endpoint_public_access
   cluster_public_access_cidrs     = local.cluster_public_access_cidrs
+  cluster_service_cidr            = local.cluster_service_cidr
 
   cluster_encryption_key_arn = local.cluster_encryption_key_arn
 


### PR DESCRIPTION
Allows configuring the EKS parameter `kubernetes_network_config.service_ipv4_cidr` for EKS users.