### PR TITLE
Allow setting GKE cluster deletion protection

### DIFF
--- a/google/_modules/gke/cluster.tf
+++ b/google/_modules/gke/cluster.tf
@@ -2,6 +2,8 @@ resource "google_container_cluster" "current" {
   project = var.project
   name    = var.metadata_name
 
+  deletion_protection = var.deletion_protection
+
   location       = var.location
   node_locations = var.node_locations
 

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -3,6 +3,11 @@ variable "project" {
   description = "Project the cluster belongs to."
 }
 
+variable "deletion_protection" {
+  type        = bool
+  description = "Must be set to false to destroy clusters."
+}
+
 variable "metadata_name" {
   type        = string
   description = "Metadata name to use."

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -17,6 +17,8 @@ locals {
 
   region = local.cfg["region"]
 
+  deletion_protection = lookup(local.cfg, "deletion_protection", null)
+
   cluster_node_locations_lookup = lookup(local.cfg, "cluster_node_locations", "")
   cluster_node_locations        = split(",", local.cluster_node_locations_lookup)
 

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -13,6 +13,8 @@ module "cluster" {
 
   project = local.project_id
 
+  deletion_protection = local.deletion_protection
+
   metadata_name   = module.cluster_metadata.name
   metadata_fqdn   = module.cluster_metadata.fqdn
   metadata_tags   = module.cluster_metadata.tags

--- a/tests/gke_zero_cluster.tf
+++ b/tests/gke_zero_cluster.tf
@@ -14,6 +14,8 @@ module "gke_zero" {
   configuration = {
     # Settings for Apps-cluster
     apps = {
+      deletion_protection = false
+
       project_id  = "terraform-kubestack-testing"
       name_prefix = "kbstacctest"
       base_domain = "infra.serverwolken.de"


### PR DESCRIPTION
Starting with provider version 5, GKE requires deletion protection to be applied as false explicitly. Otherwise a destroy of the cluster will fail.