### PR TITLE
GKE: Add support for maintenance exclusions

### DIFF
--- a/google/_modules/gke/cluster.tf
+++ b/google/_modules/gke/cluster.tf
@@ -72,6 +72,20 @@ resource "google_container_cluster" "current" {
     daily_maintenance_window {
       start_time = var.daily_maintenance_window_start_time
     }
+
+    dynamic "maintenance_exclusion" {
+      for_each = var.maintenance_exclusions
+
+      content {
+        start_time     = maintenance_exclusion.value.start_time
+        end_time       = maintenance_exclusion.value.end_time
+        exclusion_name = maintenance_exclusion.value.exclusion_name
+
+        exclusion_options {
+          scope = maintenance_exclusion.value.scope
+        }
+      }
+    }
   }
 
   dynamic "master_authorized_networks_config" {

--- a/google/_modules/gke/variables.tf
+++ b/google/_modules/gke/variables.tf
@@ -53,6 +53,16 @@ variable "daily_maintenance_window_start_time" {
   description = "Start time of the daily maintenance window."
 }
 
+variable "maintenance_exclusions" {
+  type = list(object({
+    start_time     = string
+    end_time       = string
+    exclusion_name = string
+    scope          = string
+  }))
+  description = "List of maintenance exclusion configuration to be set on the cluster."
+}
+
 variable "remove_default_node_pool" {
   type        = string
   description = "Whether to remove the default node pool. Leave true, except for upgrading from Kubestack v0.2.0-beta.0."

--- a/google/cluster/configuration.tf
+++ b/google/cluster/configuration.tf
@@ -30,6 +30,7 @@ locals {
     "cluster_daily_maintenance_window_start_time",
     "03:00",
   )
+  cluster_maintenance_exclusions = lookup(local.cfg, "cluster_maintenance_exclusions", [])
 
   remove_default_node_pool = lookup(local.cfg, "remove_default_node_pool", true)
 

--- a/google/cluster/main.tf
+++ b/google/cluster/main.tf
@@ -27,6 +27,7 @@ module "cluster" {
   release_channel    = local.cluster_release_channel
 
   daily_maintenance_window_start_time = local.cluster_daily_maintenance_window_start_time
+  maintenance_exclusions              = local.cluster_maintenance_exclusions
 
   remove_default_node_pool = local.remove_default_node_pool
 


### PR DESCRIPTION
Add support for [maintenance exclusions](https://cloud.google.com/kubernetes-engine/docs/concepts/maintenance-windows-and-exclusions#exclusions) for GKE clusters.