### PR TITLE
AKS: Set defaults to prevent showing diff on every plan

### DIFF
--- a/azurerm/_modules/aks/main.tf
+++ b/azurerm/_modules/aks/main.tf
@@ -35,6 +35,12 @@ resource "azurerm_kubernetes_cluster" "current" {
     only_critical_addons_enabled = var.default_node_pool_only_critical_addons
 
     zones = var.availability_zones
+
+    upgrade_settings {
+      max_surge                     = var.upgade_settings_max_surge
+      drain_timeout_in_minutes      = var.upgade_settings_drain_timeout_in_minutes
+      node_soak_duration_in_minutes = var.upgade_settings_node_soak_duration_in_minutes
+    }
   }
 
   network_profile {
@@ -75,9 +81,13 @@ resource "azurerm_kubernetes_cluster" "current" {
     }
   }
 
-  workload_autoscaler_profile {
-    keda_enabled                    = var.keda_enabled
-    vertical_pod_autoscaler_enabled = var.vertical_pod_autoscaler_enabled
+  dynamic "workload_autoscaler_profile" {
+    for_each = var.keda_enabled || var.vertical_pod_autoscaler_enabled ? toset([1]) : toset([])
+
+    content {
+      keda_enabled                    = var.keda_enabled
+      vertical_pod_autoscaler_enabled = var.vertical_pod_autoscaler_enabled
+    }
   }
 
   tags = var.metadata_labels

--- a/azurerm/_modules/aks/variables.tf
+++ b/azurerm/_modules/aks/variables.tf
@@ -194,11 +194,24 @@ variable "availability_zones" {
 variable "keda_enabled" {
   type        = bool
   description = "Whether KEDA Autoscaler should be enabled for the cluster."
-  default     = false
 }
 
 variable "vertical_pod_autoscaler_enabled" {
   type        = bool
   description = "Whether Vertical Pod Autoscaler should be enabled for the cluster."
-  default     = false
+}
+
+variable "upgade_settings_drain_timeout_in_minutes" {
+  type        = number
+  description = "The amount of time in minutes to wait on eviction of pods and graceful termination per node."
+}
+
+variable "upgade_settings_max_surge" {
+  type        = string
+  description = "The maximum number or percentage of nodes which will be added to the Node Pool size during an upgrade."
+}
+
+variable "upgade_settings_node_soak_duration_in_minutes" {
+  type        = number
+  description = "The amount of time in minutes to wait after draining a node and before reimaging and moving on to next node."
 }

--- a/azurerm/cluster/configuration.tf
+++ b/azurerm/cluster/configuration.tf
@@ -67,6 +67,10 @@ locals {
   additional_metadata_labels_tuples = [for t in split(",", local.additional_metadata_labels_lookup) : split("=", t)]
   additional_metadata_labels        = { for t in local.additional_metadata_labels_tuples : t[0] => t[1] if length(t) == 2 }
 
-  keda_enabled = lookup(local.cfg, "keda_enabled", false)
+  keda_enabled                    = lookup(local.cfg, "keda_enabled", false)
   vertical_pod_autoscaler_enabled = lookup(local.cfg, "vertical_pod_autoscaler_enabled", false)
+
+  upgade_settings_max_surge                     = lookup(local.cfg, "upgade_settings_max_surge", "10%")
+  upgade_settings_drain_timeout_in_minutes      = lookup(local.cfg, "upgade_settings_drain_timeout_in_minutes", 0)
+  upgade_settings_node_soak_duration_in_minutes = lookup(local.cfg, "upgade_settings_node_soak_duration_in_minutes", 0)
 }

--- a/azurerm/cluster/main.tf
+++ b/azurerm/cluster/main.tf
@@ -67,6 +67,10 @@ module "cluster" {
 
   availability_zones = local.availability_zones
 
-  keda_enabled = local.keda_enabled
+  keda_enabled                    = local.keda_enabled
   vertical_pod_autoscaler_enabled = local.vertical_pod_autoscaler_enabled
+
+  upgade_settings_max_surge                     = local.upgade_settings_max_surge
+  upgade_settings_drain_timeout_in_minutes      = local.upgade_settings_drain_timeout_in_minutes
+  upgade_settings_node_soak_duration_in_minutes = local.upgade_settings_node_soak_duration_in_minutes
 }

--- a/tests/aks_zero_cluster.tf
+++ b/tests/aks_zero_cluster.tf
@@ -13,6 +13,8 @@ module "aks_zero" {
       default_node_pool_max_count = 1
 
       network_plugin = "azure"
+
+      sku_tier = "Standard"
     }
 
     # Settings for Ops-cluster


### PR DESCRIPTION
 * workload_autoscaler_profile set conditionally based on the block's attributes
 * upgrade_settings set default values to prevent plan diff and make configurable for default node pool